### PR TITLE
feat: blue theme, reusable submenu, and Bangumi API page

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { menuLinks, siteConfig } from "@/site.config";
+import { siteConfig } from "@/site.config";
 
 const year = new Date().getFullYear();
 ---

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -40,15 +40,33 @@ import { siteConfig } from "../../site.config";
 			id="navigation-menu"
 		>
 			{
-				menuLinks.map((link) => (
-					<a
-						aria-current={Astro.url.pathname === link.path ? "page" : false}
-						class="text-accent px-2 py-4 font-semibold sm:px-4 sm:py-0 sm:underline-offset-2 sm:hover:underline"
-						href={link.path}
-					>
-						{link.title}
-					</a>
-				))
+				menuLinks.map((link) =>
+					link.children?.length ? (
+						<div class="relative px-2 py-4 font-semibold sm:px-4 sm:py-0 sm:[&:hover_.submenu]:pointer-events-auto sm:[&:hover_.submenu]:opacity-100">
+							<span class="text-accent cursor-default">{link.title} ▾</span>
+							<div class="submenu bg-global-bg mt-3 flex flex-col gap-2 sm:pointer-events-none sm:absolute sm:top-6 sm:mt-2 sm:min-w-52 sm:rounded-md sm:border sm:border-sky-200 sm:p-2 sm:opacity-0 sm:shadow-sm dark:sm:border-sky-900">
+								{link.children.map((item) => (
+									<a
+										class="text-accent rounded px-2 py-1 hover:bg-sky-100/60 dark:hover:bg-sky-900/40"
+										href={item.path}
+									>
+										{item.title}
+									</a>
+								))}
+							</div>
+						</div>
+					) : (
+						<a
+							aria-current={Astro.url.pathname === link.path ? "page" : false}
+							class="text-accent px-2 py-4 font-semibold sm:px-4 sm:py-0 sm:underline-offset-2 sm:hover:underline"
+							href={link.path}
+							target={link.external ? "_blank" : undefined}
+							rel={link.external ? "noreferrer" : undefined}
+						>
+							{link.title}
+						</a>
+					),
+				)
 			}
 		</nav>
 	</div>
@@ -80,7 +98,6 @@ import { siteConfig } from "../../site.config";
 			<svg
 				aria-hidden="true"
 				class="text-accent absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 scale-0 opacity-0 transition-all group-aria-expanded:scale-100 group-aria-expanded:opacity-100"
-				class="text-accent"
 				fill="none"
 				focusable="false"
 				id="cross-svg"

--- a/src/data/note.ts
+++ b/src/data/note.ts
@@ -1,0 +1,5 @@
+import { type CollectionEntry, getCollection } from "astro:content";
+
+export async function getAllNotes(): Promise<CollectionEntry<"note">[]> {
+	return await getCollection("note");
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -21,7 +21,9 @@ const {
 		<BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
 	</head>
 	<body
-		class="bg-global-bg text-global-text mx-auto flex min-h-screen max-w-3xl flex-col px-4 pt-16 font-mono text-sm font-normal antialiased sm:px-8"
+		class="bg-global-bg text-global-text mx-auto flex min-h-screen max-w-3xl flex-col bg-cover bg-fixed bg-center px-4 pt-16 font-mono text-sm font-normal antialiased sm:px-8"
+		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${siteConfig.backgroundImage});`}
+		data-theme-bg
 	>
 		<ThemeProvider />
 		<SkipLink />

--- a/src/pages/bangumi/index.astro
+++ b/src/pages/bangumi/index.astro
@@ -1,0 +1,84 @@
+---
+import PageLayout from "@/layouts/Base.astro";
+import { siteConfig } from "@/site.config";
+
+const username = siteConfig.bangumiUsername;
+---
+
+<PageLayout meta={{ title: "番组计划", description: "Bangumi 追番列表" }}>
+	<h1 class="title mb-6">番组计划</h1>
+	<p class="mb-3">
+		数据来源：Bangumi.tv API。当前用户：<code>{username}</code>
+	</p>
+	<p class="mb-6 text-xs opacity-80">
+		如果要换账号，修改 <code>src/site.config.ts</code> 中的 <code>bangumiUsername</code>。
+	</p>
+
+	<div class="grid gap-4" id="bangumi-list">
+		<p>正在加载追番数据...</p>
+	</div>
+</PageLayout>
+
+<script define:vars={{ username }}>
+	const endpoint = `https://api.bgm.tv/v0/users/${username}/collections?subject_type=2&limit=24`;
+	const root = document.getElementById("bangumi-list");
+
+	const statusMap = {
+		1: "想看",
+		2: "看过",
+		3: "在看",
+		4: "搁置",
+		5: "抛弃",
+	};
+
+	const escapeHtml = (value) =>
+		value
+			.replaceAll("&", "&amp;")
+			.replaceAll("<", "&lt;")
+			.replaceAll(">", "&gt;")
+			.replaceAll('"', "&quot;")
+			.replaceAll("'", "&#39;");
+
+	fetch(endpoint)
+		.then((res) => {
+			if (!res.ok) throw new Error(`Bangumi API 请求失败：${res.status}`);
+			return res.json();
+		})
+		.then((data) => {
+			const items = data?.data ?? [];
+			if (!items.length) {
+				if (root) root.innerHTML = "<p>还没有获取到追番数据。</p>";
+				return;
+			}
+
+			if (root) {
+				root.innerHTML = items
+					.map((entry) => {
+						const subject = entry?.subject;
+						const title = escapeHtml(subject?.name_cn || subject?.name || "未命名条目");
+						const image = subject?.images?.common || subject?.images?.medium || "";
+						const score = entry?.rate ? `我的评分：${entry.rate}` : "未评分";
+						const status = statusMap[entry?.type] || "未分类";
+						const url = subject?.id ? `https://bgm.tv/subject/${subject.id}` : "https://bgm.tv";
+
+						return `
+						<article class="rounded-lg border border-sky-200/80 bg-sky-50/60 p-3 dark:border-sky-900 dark:bg-sky-950/40">
+							<a href="${url}" target="_blank" rel="noreferrer" class="grid grid-cols-[70px_1fr] gap-3">
+								${image ? `<img src="${image}" alt="${title}" class="h-24 w-[70px] rounded object-cover" loading="lazy" />` : "<div class='h-24 w-[70px] rounded bg-sky-100 dark:bg-sky-900'></div>"}
+								<div>
+									<h2 class="font-semibold">${title}</h2>
+									<p class="mt-2 text-xs opacity-80">状态：${status}</p>
+									<p class="text-xs opacity-80">${score}</p>
+								</div>
+							</a>
+						</article>`;
+					})
+					.join("");
+			}
+		})
+		.catch((err) => {
+			if (root) {
+				root.innerHTML = `<p>获取 Bangumi 数据失败：${String(err)}。请检查用户名或稍后重试。</p>`;
+			}
+		});
+</script>

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,0 +1,32 @@
+---
+import PageLayout from "@/layouts/Base.astro";
+
+const meta = {
+	description: "欢迎留言～",
+	title: "Guestbook",
+};
+---
+
+<PageLayout meta={meta}>
+	<h1 class="title mb-6">Guestbook</h1>
+	<p class="mb-6">欢迎来留言！如果评论区没有显示，请检查 Twikoo 的环境变量配置。</p>
+	<div id="twikoo"></div>
+</PageLayout>
+
+<script>
+	const twikooEnvId = "https://your-twikoo-env-id.example.com";
+	if (typeof window !== "undefined") {
+		const script = document.createElement("script");
+		script.src = "https://cdn.staticfile.net/twikoo/1.6.41/twikoo.all.min.js";
+		script.defer = true;
+		script.onload = () => {
+			// @ts-expect-error twikoo is injected by script
+			twikoo.init({
+				envId: twikooEnvId,
+				el: "#twikoo",
+				path: window.location.pathname,
+			});
+		};
+		document.body.appendChild(script);
+	}
+</script>

--- a/src/pages/notes/[...page].astro
+++ b/src/pages/notes/[...page].astro
@@ -1,0 +1,59 @@
+---
+import type { CollectionEntry } from "astro:content";
+import type { GetStaticPaths, Page } from "astro";
+import { Icon } from "astro-icon/components";
+import Note from "@/components/note/Note.astro";
+import Pagination from "@/components/Paginator.astro";
+import { getAllNotes } from "@/data/note";
+import PageLayout from "@/layouts/Base.astro";
+import { collectionDateSort } from "@/utils/date";
+
+export const getStaticPaths = (async ({ paginate }) => {
+	const MAX_NOTES_PER_PAGE = 10;
+	const allNotes = await getAllNotes();
+	const allNotesByDate = allNotes.sort(collectionDateSort);
+	return paginate(allNotesByDate, {
+		pageSize: MAX_NOTES_PER_PAGE,
+	});
+}) satisfies GetStaticPaths;
+
+interface Props {
+	page: Page<CollectionEntry<"note">>;
+}
+
+const { page } = Astro.props;
+
+const meta = {
+	description: "碎碎念短博客",
+	title: "Notes",
+};
+
+const paginationProps = {
+	...(page.url.prev && {
+		prevUrl: {
+			text: "← Previous Page",
+			url: page.url.prev,
+		},
+	}),
+	...(page.url.next && {
+		nextUrl: {
+			text: "Next Page →",
+			url: page.url.next,
+		},
+	}),
+};
+---
+
+<PageLayout meta={meta}>
+	<div class="mb-12 flex items-center gap-3">
+		<h1 class="title">Notes</h1>
+		<a class="text-accent" href="/notes/rss.xml" target="_blank">
+			<span class="sr-only">Notes RSS feed</span>
+			<Icon aria-hidden="true" class="h-6 w-6" focusable="false" name="mdi:rss" />
+		</a>
+	</div>
+	<ul class="space-y-6" role="list">
+		{page.data.map((note) => <Note note={note} as="h2" isPreview />)}
+	</ul>
+	<Pagination {...paginationProps} />
+</PageLayout>

--- a/src/pages/notes/[slug].astro
+++ b/src/pages/notes/[slug].astro
@@ -1,0 +1,23 @@
+---
+import { render } from "astro:content";
+import type { GetStaticPaths } from "astro";
+import Note from "@/components/note/Note.astro";
+import { getAllNotes } from "@/data/note";
+import PageLayout from "@/layouts/Base.astro";
+
+export const getStaticPaths = (async () => {
+	const noteEntries = await getAllNotes();
+	return noteEntries.map((note) => ({
+		params: { slug: note.id },
+		props: { note },
+	}));
+}) satisfies GetStaticPaths;
+
+const { note } = Astro.props;
+await render(note);
+const noteDescription = note.data.description ?? "短博客";
+---
+
+<PageLayout meta={{ title: note.data.title, description: noteDescription }}>
+	<Note note={note} as="h1" />
+</PageLayout>

--- a/src/pages/notes/rss.xml.ts
+++ b/src/pages/notes/rss.xml.ts
@@ -1,0 +1,19 @@
+import rss from "@astrojs/rss";
+import { getAllNotes } from "@/data/note";
+import { siteConfig } from "@/site.config";
+
+export const GET = async () => {
+	const notes = await getAllNotes();
+
+	return rss({
+		title: `${siteConfig.title} - Notes`,
+		description: "短博客 RSS",
+		site: import.meta.env.SITE,
+		items: notes.map((note) => ({
+			title: note.data.title,
+			description: note.data.description,
+			pubDate: note.data.publishDate,
+			link: `notes/${note.id}/`,
+		})),
+	});
+};

--- a/src/pages/xxx/index.astro
+++ b/src/pages/xxx/index.astro
@@ -1,0 +1,8 @@
+---
+import PageLayout from "@/layouts/Base.astro";
+---
+
+<PageLayout meta={{ title: "XXX", description: "二级菜单占位页" }}>
+	<h1 class="title mb-6">XXX</h1>
+	<p>这个页面是二级菜单里的第三个栏目占位页，可以按需改名和改内容。</p>
+</PageLayout>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -1,7 +1,14 @@
 import type { AstroExpressiveCodeOptions } from "astro-expressive-code";
 import type { SiteConfig } from "@/types";
 
-export const siteConfig: SiteConfig = {
+export type MenuLink = {
+	title: string;
+	path?: string;
+	external?: boolean;
+	children?: MenuLink[];
+};
+
+export const siteConfig: SiteConfig & { backgroundImage: string; bangumiUsername: string } = {
 	// Used as both a meta property (src/components/BaseHead.astro L:31 + L:49) & the generated satori png (src/pages/og-image/[slug].png.ts)
 	author: "Eucaly",
 	// Date.prototype.toLocaleDateString() parameters, found in src/utils/date.ts.
@@ -28,34 +35,28 @@ export const siteConfig: SiteConfig = {
 	title: "幸福（？）倒計時",
 	// ! Please remember to replace the following site property with your own domain, used in astro.config.ts
 	url: "https://isntbunny.github.io/",
+	// 页面背景图（图床链接）
+	backgroundImage:
+		"https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=2000&q=80",
+	// Bangumi.tv 用户名（用于番组计划页面 API 拉取）
+	bangumiUsername: "isntbunny",
 };
 
 // Used to generate links in both the Header & Footer.
-export const menuLinks: { path: string; title: string; external?: boolean }[] = [
+export const menuLinks: MenuLink[] = [
+	{ path: "/", title: "Home" },
+	{ path: "/posts/", title: "Blog" },
+	{ path: "/notes/", title: "Notes" },
+	{ path: "https://status.cafe/users/isntbunny", title: "Memos", external: true },
+	{ path: "/gallery/", title: "Gallery" },
+	{ path: "/guestbook/", title: "Guestbook" },
 	{
-		path: "/",
-		title: "Home",
-	},
-	{
-		path: "/posts/",
-		title: "Blog",
-	},
-	{
-		path: "https://status.cafe/users/isntbunny",
-		title: "Memos",
-		external: true,
-	},
-	{
-		path: "/gallery/",
-		title: "Gallery",
-	},
-	{
-		path: "/guestbook/",
-		title: "Guestbook",
-	},
-	{
-		path: "/about/",
 		title: "About",
+		children: [
+			{ path: "/about/", title: "About" },
+			{ path: "/bangumi/", title: "番组计划" },
+			{ path: "/xxx/", title: "XXX" },
+		],
 	},
 ];
 
@@ -74,17 +75,13 @@ export const expressiveCodeOptions: AstroExpressiveCodeOptions = {
 		uiLineHeight: "inherit",
 	},
 	themeCssSelector(theme, { styleVariants }) {
-		// If one dark and one light theme are available
-		// generate theme CSS selectors compatible with cactus-theme dark mode switch
 		if (styleVariants.length >= 2) {
 			const baseTheme = styleVariants[0]?.theme;
 			const altTheme = styleVariants.find((v) => v.theme.type !== baseTheme?.type)?.theme;
 			if (theme === baseTheme || theme === altTheme) return `[data-theme='${theme.type}']`;
 		}
-		// return default selector
 		return `[data-theme="${theme.name}"]`;
 	},
-	// One dark, one light theme => https://expressive-code.com/guides/themes/#available-themes
 	themes: ["dracula", "github-light"],
 	useThemedScrollbars: false,
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,14 +6,14 @@
 /* use a selector-based strategy for dark mode */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
-/* you could refactor below to use light-dark(), depending on your target audience */
 @theme {
-	--color-global-bg: oklch(98.48% 0 0);
-	--color-global-text: oklch(26.99% 0.0096 235.05);
-	--color-link: oklch(55.44% 0.0431 185.69);
-	--color-accent: oklch(55.27% 0.195 19.06);
-	--color-accent-2: oklch(18.15% 0 0);
-	--color-quote: oklch(55.27% 0.195 19.06);
+	--color-global-bg: oklch(97.5% 0.02 235);
+	--color-global-text: oklch(30% 0.04 245);
+	--color-link: oklch(52% 0.13 240);
+	--color-accent: oklch(58% 0.14 225);
+	--color-accent-2: oklch(34% 0.07 245);
+	--color-quote: oklch(50% 0.08 235);
+	--color-bg-overlay: rgba(240, 248, 255, 0.82);
 }
 
 @layer base {
@@ -28,12 +28,13 @@
 
 		&[data-theme="dark"] {
 			color-scheme: dark;
-			--color-global-bg: oklch(23.64% 0.0045 248);
-			--color-global-text: oklch(83.54% 0 264);
-			--color-link: oklch(70.44% 0.1133 349);
-			--color-accent: oklch(70.91% 0.1415 163.7);
-			--color-accent-2: oklch(94.66% 0 0);
-			--color-quote: oklch(94.8% 0.106 136.49);
+			--color-global-bg: oklch(20% 0.03 250);
+			--color-global-text: oklch(88% 0.02 245);
+			--color-link: oklch(80% 0.12 230);
+			--color-accent: oklch(77% 0.14 225);
+			--color-accent-2: oklch(91% 0.03 240);
+			--color-quote: oklch(82% 0.07 235);
+			--color-bg-overlay: rgba(12, 22, 35, 0.72);
 		}
 	}
 
@@ -45,7 +46,6 @@
 		navigation: auto;
 	}
 
-	/* Astro image responsive styles, modified from -> https://docs.astro.build/en/guides/images/#responsive-image-styles */
 	:where([data-astro-image]) {
 		object-fit: var(--fit);
 		object-position: var(--pos);


### PR DESCRIPTION
### Motivation
- Provide a light-blue visual identity with proper dark-mode support so colors (text, links, accents, quotes, overlay) adapt for readability across themes.
- Make navigation second-level menus data-driven so any top-level item can have children without special-casing `About`.
- Rename the Bangumi link to `番组计划` and surface a page that fetches the user's Bangumi collection via the Bangumi API.

### Description
- Rethemed site color tokens and added `--color-bg-overlay` to `src/styles/global.css` so the background overlay adapts for light/dark modes.
- Updated `src/layouts/Base.astro` to use the new overlay variable for the background image (`style` now uses `var(--color-bg-overlay)`).
- Introduced a `MenuLink` shape and made `menuLinks` configurable in `src/site.config.ts`, adding `children` and a new `bangumiUsername` property for API use.
- Refactored `src/components/layout/Header.astro` to render top-level links from `menuLinks` and render hover-only submenus for items with `children` (parent is non-clickable by design).
- Implemented `src/pages/bangumi/index.astro` which uses the configured `bangumiUsername` and client-side fetch to `https://api.bgm.tv/v0/users/${username}/collections` to render collection cards (cover, status, score, link).
- Minor cleanup: removed an unused import in `Footer.astro` and added supporting pages/components for Notes and Guestbook used by the previous work.

### Testing
- Ran `npm run check` and the project reported no errors (one Astro script hint about `define:vars` is informational).
- Ran `npm run build` and a full static build completed successfully and generated routes including `/bangumi/`.
- Started the dev server (`npm run dev`) and used an automated Playwright script to verify the header submenu in light/dark modes and capture screenshots, and to open the `/bangumi/` page showing API-rendered items; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afa5604b8832c8fe20de6ae62233e)