### PR TITLE
Refactor site styling/theme config and simplify UI

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -31,11 +31,11 @@ import "@/styles/blocks/search.css";
 	</button>
 	<dialog
 		aria-label="search"
-		class="bg-global-bg h-full max-h-full w-full max-w-full border border-zinc-400 shadow-sm backdrop:backdrop-blur-sm open:flex sm:mx-auto sm:mt-16 sm:mb-auto sm:h-max sm:max-h-[calc(100%-8rem)] sm:min-h-[15rem] sm:w-5/6 sm:max-w-[48rem] sm:rounded-md"
+		class="glass-panel bg-global-bg/92 h-full max-h-full w-full max-w-full shadow-lg backdrop:bg-slate-900/35 backdrop:backdrop-blur-sm open:flex sm:mx-auto sm:mt-16 sm:mb-auto sm:h-max sm:max-h-[calc(100%-8rem)] sm:min-h-[15rem] sm:w-11/12 sm:max-w-[48rem] sm:rounded-xl"
 	>
-		<div class="dialog-frame flex grow flex-col gap-4 p-6 pt-12 sm:pt-6">
+		<div class="dialog-frame flex grow flex-col gap-4 p-4 pt-10 sm:p-6 sm:pt-6">
 			<button
-				class="ms-auto cursor-pointer rounded-md bg-zinc-200 p-2 font-semibold dark:bg-zinc-700"
+				class="ms-auto cursor-pointer rounded-md bg-white/60 px-3 py-2 font-semibold dark:bg-slate-800/70"
 				data-close-modal>Close</button
 			>
 			{

--- a/src/components/ThemeProvider.astro
+++ b/src/components/ThemeProvider.astro
@@ -1,5 +1,9 @@
+---
+import { themeCssVars } from "@/config/theme";
+---
+
 {/* Inlined to avoid FOUC. This is a parser blocking script. */}
-<script is:inline>
+<script define:vars={{ darkVars: themeCssVars.dark, lightVars: themeCssVars.light }} is:inline>
 	const lightModePref = window.matchMedia("(prefers-color-scheme: light)");
 
 	function getStoredTheme() {
@@ -9,6 +13,10 @@
 	function getUserPref() {
 		const storedTheme = getStoredTheme();
 		return storedTheme || (lightModePref.matches ? "light" : "dark");
+	}
+
+	function applyThemeVars(root, theme) {
+		root.style.cssText += theme === "dark" ? darkVars : lightVars;
 	}
 
 	function setTheme(newTheme, persist = true) {
@@ -22,6 +30,7 @@
 		if (newTheme === root.getAttribute("data-theme")) return;
 
 		root.setAttribute("data-theme", newTheme);
+		applyThemeVars(root, newTheme);
 
 		if (persist && typeof localStorage !== "undefined") {
 			localStorage.setItem("theme", newTheme);

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,26 +1,45 @@
 ---
-import { siteConfig } from "@/site.config";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
-const year = new Date().getFullYear();
+const startDateISO = "2025-07-30T00:00:00+08:00";
+
+const countContentCharacters = (dir: string): number => {
+	let total = 0;
+	for (const entry of readdirSync(dir)) {
+		const target = join(dir, entry);
+		const stat = statSync(target);
+		if (stat.isDirectory()) {
+			total += countContentCharacters(target);
+			continue;
+		}
+		if (!/\.(md|mdx)$/i.test(entry)) continue;
+		const text = readFileSync(target, "utf-8");
+		total += text.replace(/\s+/g, "").length;
+	}
+	return total;
+};
+
+const contentChars = countContentCharacters("src/content");
 ---
 
 <footer
 	class="mt-auto flex w-full flex-col items-center justify-center gap-y-2 pt-20 pb-4 text-center align-top font-semibold text-gray-600 sm:flex-row sm:justify-between sm:text-xs dark:text-gray-400"
 >
-	<div class="me-0 sm:me-4">
-		&copy; {siteConfig.author}
-		{year}.<span class="inline-block">&nbsp;💊&nbsp;{siteConfig.title}</span>
-	</div>
-	<div id="site-runtime">此网站运行了计算中...</div>
+	<div class="me-0 sm:me-4">&copy; Eucaly 2026.</div>
+	<div id="site-runtime" data-start-date={startDateISO} data-total-words={contentChars}>此网站运行了计算中...</div>
 </footer>
 
 <script is:inline>
-	const startDate = new Date("2025-07-30T00:00:00+08:00");
-	const now = new Date();
-	const days = Math.max(
-		1,
-		Math.floor((now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1,
-	);
 	const runtimeEl = document.getElementById("site-runtime");
-	if (runtimeEl) runtimeEl.textContent = `此网站运行了 ${days} 天`;
+	if (runtimeEl) {
+		const startDate = new Date(runtimeEl.dataset.startDate || "2025-07-30T00:00:00+08:00");
+		const totalWords = Number(runtimeEl.dataset.totalWords || "0");
+		const now = new Date();
+		const days = Math.max(
+			1,
+			Math.floor((now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1,
+		);
+		runtimeEl.textContent = `此网站运行了 ${days} 天，共嘟嘟了 ${totalWords} 字`;
+	}
 </script>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -16,7 +16,7 @@ import { siteConfig } from "../../site.config";
 		</a>
 		<nav
 			aria-label="Main menu"
-			class="bg-global-bg/95 absolute -inset-x-4 top-12 hidden flex-col divide-y px-2 py-4 shadow-md backdrop-blur-sm group-[.menu-open]:z-50 group-[.menu-open]:flex sm:static sm:z-auto sm:-ms-4 sm:mt-1 sm:flex sm:flex-row sm:divide-x sm:divide-y-0 sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-none dark:bg-zinc-900 sm:dark:bg-transparent"
+			class="bg-global-bg/95 absolute -inset-x-4 top-12 hidden flex-col px-2 py-4 shadow-md backdrop-blur-sm group-[.menu-open]:z-50 group-[.menu-open]:flex sm:static sm:z-auto sm:-ms-4 sm:mt-1 sm:flex sm:flex-row sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-none dark:bg-zinc-900 sm:dark:bg-transparent"
 			id="navigation-menu"
 		>
 			{
@@ -32,7 +32,7 @@ import { siteConfig } from "../../site.config";
 								{link.title} ▾
 							</button>
 							<div
-								class="submenu bg-global-bg mt-2 hidden flex-col gap-2 sm:absolute sm:start-0 sm:top-full sm:min-w-52 sm:rounded-md sm:border sm:border-sky-200 sm:p-2 sm:shadow-sm dark:bg-zinc-900 dark:sm:border-sky-900"
+								class="submenu bg-global-bg mt-2 hidden flex-col gap-2 sm:absolute sm:start-0 sm:top-full sm:min-w-52 sm:rounded-md sm:p-2 sm:shadow-sm dark:bg-zinc-900"
 								data-submenu={index}
 							>
 								{link.children.map((item) => (

--- a/src/config/home.ts
+++ b/src/config/home.ts
@@ -1,0 +1,12 @@
+export const homeConfig = {
+	typingText: "幸せのカウントダウン",
+	welcomeText: "欢迎来自远方的朋友~",
+	countdownTargets: [
+		{ key: "monthEnd", label: "距离月末还有", suffix: "天" },
+		{ key: "nextYear", label: "距离下一年还有", suffix: "天" },
+		{ key: "gaokao2027", label: "距离2027年高考还有", suffix: "天" },
+	],
+	galleryCardImage: "https://i.postimg.cc/43GZ382v/e2511.png",
+	profileCoverImage: "https://i.postimg.cc/4dLTBX4R/e250416.jpg",
+	defaultColor: "#22C55E",
+} as const;

--- a/src/config/site-settings.ts
+++ b/src/config/site-settings.ts
@@ -2,11 +2,6 @@ export const siteSettings = {
 	font: {
 		bodyClass: "font-mono",
 	},
-	backgrounds: {
-		home: "https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=2000&q=80",
-		default:
-			"https://i.postimg.cc/J0bfgL1S/hitori_band_playing_bocchi_the_rock_hd_wallpaper_uhdpaper_com_395_5_k.jpg",
-	},
 	comments: {
 		twikoo: {
 			envId: "https://your-twikoo-env-id.example.com",

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,65 @@
+export const themeConfig = {
+	colors: {
+		light: {
+			globalBg: "oklch(96% 0.018 220)",
+			globalText: "oklch(34% 0.03 232)",
+			link: "oklch(52% 0.085 220)",
+			accent: "oklch(60% 0.09 218)",
+			accent2: "oklch(38% 0.045 232)",
+			quote: "oklch(48% 0.055 220)",
+			bgOverlay: "rgba(236, 245, 248, 0.78)",
+			surface: "rgba(255, 255, 255, 0.7)",
+		},
+		dark: {
+			globalBg: "oklch(24% 0.02 232)",
+			globalText: "oklch(90% 0.018 225)",
+			link: "oklch(76% 0.09 220)",
+			accent: "oklch(73% 0.08 215)",
+			accent2: "oklch(90% 0.02 230)",
+			quote: "oklch(78% 0.05 218)",
+			bgOverlay: "rgba(10, 20, 28, 0.65)",
+			surface: "rgba(17, 28, 37, 0.62)",
+		},
+	},
+	backgrounds: {
+		home: "https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=2000&q=80",
+		default:
+			"https://i.postimg.cc/J0bfgL1S/hitori_band_playing_bocchi_the_rock_hd_wallpaper_uhdpaper_com_395_5_k.jpg",
+		pages: {
+			"/gallery/":
+				"https://images.unsplash.com/photo-1508261303786-79cf9a29f6f3?auto=format&fit=crop&w=2000&q=80",
+		},
+	},
+} as const;
+
+const toCssVars = (vars: Record<string, string>) =>
+	Object.entries(vars)
+		.map(([key, value]) => `--${key}: ${value};`)
+		.join("\n");
+
+export const themeCssVars = {
+	light: toCssVars({
+		"color-global-bg": themeConfig.colors.light.globalBg,
+		"color-global-text": themeConfig.colors.light.globalText,
+		"color-link": themeConfig.colors.light.link,
+		"color-accent": themeConfig.colors.light.accent,
+		"color-accent-2": themeConfig.colors.light.accent2,
+		"color-quote": themeConfig.colors.light.quote,
+		"color-bg-overlay": themeConfig.colors.light.bgOverlay,
+		"color-surface": themeConfig.colors.light.surface,
+	}),
+	dark: toCssVars({
+		"color-global-bg": themeConfig.colors.dark.globalBg,
+		"color-global-text": themeConfig.colors.dark.globalText,
+		"color-link": themeConfig.colors.dark.link,
+		"color-accent": themeConfig.colors.dark.accent,
+		"color-accent-2": themeConfig.colors.dark.accent2,
+		"color-quote": themeConfig.colors.dark.quote,
+		"color-bg-overlay": themeConfig.colors.dark.bgOverlay,
+		"color-surface": themeConfig.colors.dark.surface,
+	}),
+};
+
+export const getPageBackground = (pathname: string) =>
+	themeConfig.backgrounds.pages[pathname as keyof typeof themeConfig.backgrounds.pages] ||
+	themeConfig.backgrounds.default;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -56,9 +56,23 @@ const tag = defineCollection({
 	}),
 });
 
+const gallery = defineCollection({
+	loader: glob({ base: "./src/content/gallery", pattern: "**/*.{md,mdx}" }),
+	schema: z.object({
+		title: z.string(),
+		items: z.array(
+			z.object({
+				title: z.string(),
+				image: z.string().url(),
+				description: z.string().optional(),
+			}),
+		),
+	}),
+});
+
 const page = defineCollection({
 	loader: glob({ base: "./src/content/page", pattern: "**/*.{md,mdx}" }),
 	schema: z.object({}),
 });
 
-export const collections = { post, note, tag, page };
+export const collections = { post, note, tag, page, gallery };

--- a/src/content/gallery/index.md
+++ b/src/content/gallery/index.md
@@ -1,0 +1,13 @@
+---
+title: 我的画廊
+items:
+  - title: 夜色中的街道
+    image: https://images.unsplash.com/photo-1520012218364-5f4f987fbc33?auto=format&fit=crop&w=1200&q=80
+    description: 低饱和的夜景，适合当背景。
+  - title: 海边清晨
+    image: https://images.unsplash.com/photo-1473116763249-2faaef81ccda?auto=format&fit=crop&w=1200&q=80
+    description: mizuro 水色氛围练习。
+  - title: 青色玻璃
+    image: https://images.unsplash.com/photo-1519608487953-e999c86e7455?auto=format&fit=crop&w=1200&q=80
+    description: 半透明材质参考。
+---

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,7 +4,7 @@ import Footer from "@/components/layout/Footer.astro";
 import Header from "@/components/layout/Header.astro";
 import SkipLink from "@/components/SkipLink.astro";
 import ThemeProvider from "@/components/ThemeProvider.astro";
-import { siteSettings } from "@/config/site-settings";
+import { getPageBackground, themeConfig } from "@/config/theme";
 import { siteConfig } from "@/site.config";
 import type { SiteMeta } from "@/types";
 
@@ -16,6 +16,9 @@ const {
 	meta: { articleDate, description = siteConfig.description, ogImage, title },
 } = Astro.props;
 const isHome = Astro.url.pathname === "/";
+const pageBackground = isHome
+	? themeConfig.backgrounds.home
+	: getPageBackground(Astro.url.pathname);
 ---
 
 <html class="scroll-smooth" lang={siteConfig.lang}>
@@ -23,9 +26,9 @@ const isHome = Astro.url.pathname === "/";
 		<BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
 	</head>
 	<body
-		class={`bg-global-bg text-global-text mx-auto flex min-h-screen max-w-4xl flex-col bg-cover bg-scroll bg-center px-4 pt-8 ${siteSettings.font.bodyClass} text-base font-normal antialiased sm:bg-fixed sm:px-8 sm:pt-16`}
+		class={`bg-global-bg text-global-text mx-auto flex min-h-screen max-w-4xl flex-col bg-cover bg-scroll bg-center px-4 pt-8 text-base font-normal antialiased sm:bg-fixed sm:px-8 sm:pt-16`}
 		class:list={[isHome && "home-page-bg"]}
-		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${isHome ? siteSettings.backgrounds.home : siteConfig.backgroundImage});`}
+		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${pageBackground});`}
 		data-theme-bg
 	>
 		<ThemeProvider />

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -1,26 +1,22 @@
 ---
-import { getEntry, render } from "astro:content";
+import { getCollection } from "astro:content";
 import PageLayout from "@/layouts/Base.astro";
 
-const sourceUrl = "https://postimg.cc/gallery/tHJV36qY";
-const galleryEntry = await getEntry("page", "gallery");
-if (!galleryEntry) throw new Error("Missing src/content/page/gallery.md");
-const { Content } = await render(galleryEntry);
+const [gallery] = await getCollection("gallery");
+if (!gallery) throw new Error("Missing src/content/gallery/index.md");
 ---
 
 <PageLayout meta={{ title: "Gallery", description: "我的画廊" }}>
-	<h1 class="title mb-6">Gallery</h1>
-	<div class="prose prose-sm prose-cactus mb-6 max-w-none">
-		<Content />
+	<h1 class="title mb-6">{gallery.data.title}</h1>
+	<div class="grid gap-6 sm:grid-cols-2">
+		{gallery.data.items.map((item) => (
+			<article class="glass-panel overflow-hidden rounded-xl">
+				<img src={item.image} alt={item.title} class="h-56 w-full object-cover" loading="lazy" />
+				<div class="p-4">
+					<h2 class="text-lg font-semibold">{item.title}</h2>
+					{item.description && <p class="mt-2 text-sm opacity-80">{item.description}</p>}
+				</div>
+			</article>
+		))}
 	</div>
-	<p class="mb-6">
-		<a class="cactus-link" href={sourceUrl} target="_blank" rel="noreferrer">打开画廊（新窗口）</a>
-	</p>
-
-	<iframe
-		title="Postimg Gallery"
-		src={sourceUrl}
-		class="mb-6 h-[75vh] w-full rounded-lg border border-sky-200 dark:border-sky-900"
-		loading="lazy"
-	></iframe>
 </PageLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { execSync } from "node:child_process";
 import Search from "@/components/Search.astro";
+import { homeConfig } from "@/config/home";
 import { getAllPosts } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
 import { menuLinks } from "@/site.config";
@@ -16,11 +17,12 @@ const gaokao2027 = new Date("2027-06-07T00:00:00+08:00");
 const daysLeft = (targetDate: Date) =>
 	Math.max(0, Math.ceil((targetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)));
 
-const countdownItems = [
-	{ label: "距离月末还有", days: daysLeft(monthEnd), suffix: "天" },
-	{ label: "距离下一年还有", days: daysLeft(nextYear), suffix: "天" },
-	{ label: "距离2027年高考还有", days: daysLeft(gaokao2027), suffix: "天" },
-];
+const countdownTargetMap = { monthEnd, nextYear, gaokao2027 } as const;
+
+const countdownItems = homeConfig.countdownTargets.map((item) => ({
+	...item,
+	days: daysLeft(countdownTargetMap[item.key]),
+}));
 
 const homepageTags = [...new Set(allPostsByDate.flatMap((p) => p.data.tags))].slice(0, 20);
 
@@ -43,12 +45,12 @@ const daysSinceLastCommit = (() => {
 <PageLayout meta={{ title: "Home" }}>
 	<section class="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
 		<div class="space-y-6">
-			<section class="rounded-md border border-zinc-200 bg-global-bg/80 p-5 dark:border-zinc-800">
+			<section class="glass-panel rounded-md p-5">
 				<h1 class="title mb-3" id="home-typing"></h1>
 				<p id="home-location">欢迎来自远方的朋友~</p>
 			</section>
 
-			<section class="rounded-md border border-zinc-200 bg-global-bg/80 p-5 dark:border-zinc-800">
+			<section class="glass-panel rounded-md p-5">
 				<h2 class="title mb-4 text-xl">倒计时</h2>
 				<ul class="space-y-3">
 					{countdownItems.map((item) => (
@@ -64,48 +66,48 @@ const daysSinceLastCommit = (() => {
 			</section>
 
 			<a
-				class="block overflow-hidden rounded-md border border-zinc-200 bg-global-bg/80 p-1 transition hover:border-sky-400 dark:border-zinc-800"
+				class="glass-panel block overflow-hidden rounded-md p-1 transition hover:bg-white/80 dark:hover:bg-slate-900/80"
 				href="/gallery/"
 			>
 				<div
 					class="h-30 rounded-md bg-cover bg-center"
-					style="background-image:url('https://i.postimg.cc/43GZ382v/e2511.png')"
+					style={`background-image:url('${homeConfig.galleryCardImage}')`}
 				></div>
 				<p class="py-2 text-center font-semibold text-sky-500">Gallery</p>
 			</a>
 
 
-			<section class="rounded-md border border-zinc-200 bg-global-bg/80 p-5 dark:border-zinc-800">
+			<section class="glass-panel rounded-md p-5">
 				<h2 class="title mb-4 text-xl">取色器</h2>
 				<div class="flex flex-col gap-3">
-					<input class="h-36 w-full cursor-pointer rounded-md" id="home-color-picker" type="color" value="#22c55e" />
+					<input class="h-36 w-full cursor-pointer rounded-md" id="home-color-picker" type="color" value={homeConfig.defaultColor} />
 					<input
-						class="rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900"
+						class="rounded-md bg-white/75 px-3 py-2 dark:bg-slate-900/70"
 						id="home-color-hex"
 						type="text"
-						value="#22c55e"
+						value={homeConfig.defaultColor}
 					/>
 				</div>
 			</section>
 		</div>
 
 		<div class="space-y-6">
-			<section class="rounded-md border border-zinc-200 bg-global-bg/80 p-4 dark:border-zinc-800">
+			<section class="glass-panel rounded-md p-4">
 				<img
 					alt="homepage cover"
 					class="mb-3 h-44 w-full rounded-md object-cover"
-					src="https://i.postimg.cc/4dLTBX4R/e250416.jpg"
+					src={homeConfig.profileCoverImage}
 				/>
 				<p class="text-sm text-zinc-600 dark:text-zinc-400">上次更新距今 {daysSinceLastCommit} days ago</p>
 			</section>
 
-			<section class="rounded-md border border-zinc-200 bg-global-bg/80 p-5 dark:border-zinc-800">
+			<section class="glass-panel rounded-md p-5">
 				<h2 class="title mb-4 text-center text-xl">导航</h2>
 				<div class="hidden"><Search /></div>
 				<nav aria-label="Home quick links" class="flex flex-col gap-2 text-center">
 					{rightNavLinks.map((link) => (
 						<a
-							class="rounded-md border border-zinc-200 px-3 py-2 hover:border-sky-300 hover:bg-sky-50/60 dark:border-zinc-700 dark:hover:border-sky-800 dark:hover:bg-sky-900/30"
+							class="glass-panel rounded-md px-3 py-2 hover:bg-sky-100/70 dark:hover:bg-sky-900/30"
 							href={link.path}
 							target={link.external ? "_blank" : undefined}
 							rel={link.external ? "noreferrer" : undefined}
@@ -118,7 +120,7 @@ const daysSinceLastCommit = (() => {
 
 			{
 				homepageTags.length > 0 && (
-					<section class="rounded-md border border-zinc-200 bg-global-bg/80 p-5 dark:border-zinc-800">
+					<section class="glass-panel rounded-md p-5">
 						<h2 class="title mb-4 text-xl">Tags</h2>
 						<div class="flex flex-wrap gap-2">
 							{homepageTags.map((tag) => (
@@ -134,21 +136,21 @@ const daysSinceLastCommit = (() => {
 	</section>
 </PageLayout>
 
-<script is:inline>
+<script define:vars={{ typingText: homeConfig.typingText, welcomeText: homeConfig.welcomeText }} is:inline>
 	const initHomeHero = () => {
 		const typingTarget = document.getElementById("home-typing");
-		const typingText = "幸せのカウントダウン";
+		const typingValue = typingText;
 		let idx = 0;
 		let deleting = false;
 		if (window.__homeTypingTimer) clearInterval(window.__homeTypingTimer);
 		window.__homeTypingTimer = setInterval(() => {
 			if (!typingTarget) return;
-			typingTarget.textContent = typingText.slice(0, idx);
+			typingTarget.textContent = typingValue.slice(0, idx);
 			if (!deleting) {
 				idx += 1;
-				if (idx > typingText.length) {
+				if (idx > typingValue.length) {
 					deleting = true;
-					idx = typingText.length;
+					idx = typingValue.length;
 				}
 			} else {
 				idx -= 1;
@@ -160,6 +162,7 @@ const daysSinceLastCommit = (() => {
 		}, 120);
 
 		const locationTarget = document.getElementById("home-location");
+		if (locationTarget) locationTarget.textContent = welcomeText;
 		fetch("https://ipapi.co/json/")
 			.then((res) => res.json())
 			.then((data) => {
@@ -170,7 +173,7 @@ const daysSinceLastCommit = (() => {
 				if (locationTarget) locationTarget.textContent = `欢迎来自${locationName}的朋友~`;
 			})
 			.catch(() => {
-				if (locationTarget) locationTarget.textContent = "欢迎来自远方的朋友~";
+				if (locationTarget) locationTarget.textContent = welcomeText;
 			});
 
 		const player = document.getElementById("home-audio");

--- a/src/pages/memos/[...page].astro
+++ b/src/pages/memos/[...page].astro
@@ -76,15 +76,11 @@ const paginationProps = {
 					<Note note={memo.note} as="h2" isPreview />
 				</li>
 			) : (
-				<li class="bg-global-text/5 inline-grid w-full rounded-md px-4 py-3">
-					<p class="text-xs font-semibold uppercase tracking-wider text-sky-500">status.cafe</p>
+				<li class="glass-panel inline-grid w-full rounded-md px-4 py-3">
 					<time class="mt-1 block text-sm text-gray-500 dark:text-gray-400" datetime={memo.publishDate.toISOString()}>
 						{memo.publishDate.toLocaleString("zh-CN")}
 					</time>
 					<p class="mt-3 whitespace-pre-wrap">{memo.text}</p>
-					{memo.link && (
-						<a class="mt-2 text-sm text-sky-600 hover:underline dark:text-sky-400" href={memo.link} target="_blank" rel="noreferrer">查看原状态</a>
-					)}
 				</li>
 			),
 		)}

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -1,6 +1,6 @@
 import type { AstroExpressiveCodeOptions } from "astro-expressive-code";
 import type { SiteConfig } from "@/types";
-import { siteSettings } from "./config/site-settings";
+import { themeConfig } from "./config/theme";
 
 export type MenuLink = {
 	title: string;
@@ -36,15 +36,14 @@ export const siteConfig: SiteConfig & { backgroundImage: string; bangumiUsername
 	title: "幸せのカウントダウン",
 	// ! Please remember to replace the following site property with your own domain, used in astro.config.ts
 	url: "https://isntbunny.github.io/",
-	// 页面背景图（图床链接）
-	backgroundImage: siteSettings.backgrounds.default,
+	// 页面背景图
+	backgroundImage: themeConfig.backgrounds.default,
 	// Bangumi.tv 用户名（用于番组计划页面 API 拉取）
 	bangumiUsername: "isntbunny",
 };
 
 // Used to generate links in both the Header & Footer.
 export const menuLinks: MenuLink[] = [
-	{ path: "/", title: "Home" },
 	{ path: "/posts/", title: "Blog" },
 	{ path: "/memos/", title: "Memos" },
 	{ path: "/gallery/", title: "Gallery" },

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -7,13 +7,13 @@
 #cactus__search {
 	--pagefind-ui-primary: var(--color-accent);
 	--pagefind-ui-text: var(--color-global-text);
-	--pagefind-ui-background: var(--color-zinc-100);
-	--pagefind-ui-border: var(--color-zinc-300);
-	--pagefind-ui-border-width: 1px;
+	--pagefind-ui-background: var(--color-surface);
+	--pagefind-ui-border: transparent;
+	--pagefind-ui-border-width: 0px;
 
 	[data-theme="dark"] & {
-		--pagefind-ui-background: var(--color-zinc-800);
-		--pagefind-ui-border: var(--color-zinc-500);
+		--pagefind-ui-background: var(--color-surface);
+		--pagefind-ui-border: transparent;
 	}
 }
 
@@ -72,4 +72,12 @@
 	color: var(--color-quote);
 	background-color: transparent;
 	font-weight: 600;
+}
+
+#cactus__search .pagefind-ui__drawer,
+#cactus__search .pagefind-ui__search-input,
+#cactus__search .pagefind-ui__result {
+	border: 0;
+	background: color-mix(in oklab, var(--color-surface) 90%, transparent);
+	border-radius: 0.75rem;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,13 +7,14 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
-	--color-global-bg: oklch(97.5% 0.02 235);
-	--color-global-text: oklch(30% 0.04 245);
-	--color-link: oklch(52% 0.13 240);
-	--color-accent: oklch(58% 0.14 225);
-	--color-accent-2: oklch(34% 0.07 245);
-	--color-quote: oklch(50% 0.08 235);
-	--color-bg-overlay: rgba(240, 248, 255, 0.82);
+	--color-global-bg: oklch(96% 0.018 220);
+	--color-global-text: oklch(34% 0.03 232);
+	--color-link: oklch(52% 0.085 220);
+	--color-accent: oklch(60% 0.09 218);
+	--color-accent-2: oklch(38% 0.045 232);
+	--color-quote: oklch(48% 0.055 220);
+	--color-bg-overlay: rgba(236, 245, 248, 0.78);
+	--color-surface: rgba(255, 255, 255, 0.7);
 }
 
 @layer base {
@@ -28,13 +29,6 @@
 
 		&[data-theme="dark"] {
 			color-scheme: dark;
-			--color-global-bg: oklch(20% 0.03 250);
-			--color-global-text: oklch(88% 0.02 245);
-			--color-link: oklch(80% 0.12 230);
-			--color-accent: oklch(77% 0.14 225);
-			--color-accent-2: oklch(91% 0.03 240);
-			--color-quote: oklch(82% 0.07 235);
-			--color-bg-overlay: rgba(12, 22, 35, 0.72);
 		}
 	}
 
@@ -42,7 +36,7 @@
 		background-color: var(--color-global-bg);
 	}
 
-	:where(.border, [class^="border-"], [class*=" border-"]) {
+	:where(*) {
 		border-style: none;
 	}
 
@@ -83,6 +77,11 @@
 	.title {
 		@apply text-accent-2 text-2xl font-semibold;
 	}
+
+	.glass-panel {
+		background: var(--color-surface);
+		backdrop-filter: blur(6px);
+	}
 }
 
 @utility prose {
@@ -94,5 +93,5 @@
 	--tw-prose-hr: 0.5px dashed #666;
 	--tw-prose-links: var(--color-global-text);
 	--tw-prose-quotes: var(--color-quote);
-	--tw-prose-th-borders: #666;
+	--tw-prose-th-borders: transparent;
 }


### PR DESCRIPTION
### Motivation
- 集中主题与首页配置为可编辑的 TS，便于在白天/黑夜与页面级背景之间快速调整配色与图像。 
- 将所有带边框的模块改为无边框半透明面板（glass），以实现更统一的低对比度 mizuro 水色视觉风格。 
- 使用本地 Markdown 驱动画廊并精简 memos 列表以移除外部依赖与冗余链接，优化移动端搜索弹窗 UI。 

### Description
- 新增 `src/config/theme.ts` 与 `src/config/home.ts`，并在 `ThemeProvider.astro` 中按主题注入 CSS 变量以实现集中化配色与页面背景映射。 
- 将全局样式改为无边框处理并新增 `glass-panel` 样式（半透明模糊面板），并更新 `src/styles/global.css` 与 `src/styles/blocks/search.css` 以移除边框并优化搜索面板在移动端的显示。 
- 更新 Header/Footer/Home/Memos/Gallery/Search 等组件以使用新配置并实现视觉调整，具体包括：移除导航中的 `Home`、memos 卡片中 `status.cafe` 标签与“查看原状态”链接、页脚左侧改为固定 `© Eucaly 2026.` 并在右侧显示运行天数与构建时统计的总字数。 
- 将画廊从外部 iframe 切换为内容集合 `gallery`，新增 `src/content/gallery/index.md` 并修改 `src/pages/gallery.astro` 使用该集合渲染图片卡片。 

### Testing
- 运行 `pnpm lint`（biome）并修正样式警告，检查通过。 
- 运行 `pnpm build`（包含 postbuild 的 Pagefind 索引）成功完成并生成静态站点与搜索索引。 
- 尝试使用 Playwright 在本环境捕获移动端搜索弹窗截图时浏览器进程在该环境崩溃（SIGSEGV），因此未生成截图。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c04cb3aa4832ca51eb73fd407f9b5)