### PR TITLE
Refine homepage alignment and implement live memos stream with comments

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,16 +1,10 @@
 ---
 import Search from "@/components/Search.astro";
 import ThemeToggle from "@/components/ThemeToggle.astro";
-import { homeConfig } from "@/settings/site";
 import { menuLinks } from "@/site.config";
 ---
 
 <header class="mb-8" id="main-header">
-	<div class="home-top-strip mb-3">
-		<a aria-current={Astro.url.pathname === "/" ? "page" : false} class="home-top-image-link" href="/">
-			<img alt="top banner" class="home-top-image" src={homeConfig.topBannerImage} />
-		</a>
-	</div>
 	<div class="win-nav-wrap flex items-center justify-between gap-2">
 		<nav aria-label="Main menu" class="win-nav hidden sm:flex" id="navigation-menu">
 			{menuLinks.map((link, index) =>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,7 +4,7 @@ import Footer from "@/components/layout/Footer.astro";
 import Header from "@/components/layout/Header.astro";
 import SkipLink from "@/components/SkipLink.astro";
 import ThemeProvider from "@/components/ThemeProvider.astro";
-import { getPageBackground, siteSettings } from "@/settings/site";
+import { getPageBackground, homeConfig, siteSettings } from "@/settings/site";
 import { siteConfig } from "@/site.config";
 import type { SiteMeta } from "@/types";
 
@@ -24,18 +24,26 @@ const pageBackground = isHome ? siteSettings.backgrounds.home : getPageBackgroun
 		<BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
 	</head>
 	<body
-		class={`bg-global-bg text-global-text mx-auto flex min-h-screen max-w-4xl flex-col bg-cover bg-scroll bg-center px-4 pt-8 text-base font-normal antialiased sm:bg-fixed sm:px-8 sm:pt-16`}
+		class={`bg-global-bg text-global-text mx-auto flex min-h-screen w-full max-w-6xl flex-col bg-cover bg-scroll bg-center px-4 pt-8 text-base font-normal antialiased sm:bg-fixed sm:px-8 sm:pt-10`}
 		class:list={[isHome && "home-page-bg"]}
 		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${pageBackground});`}
 		data-theme-bg
 	>
 		<ThemeProvider />
 		<SkipLink />
-		{!isHome && <Header />}
-		<main id="main">
-			<slot />
-		</main>
-		<Footer />
+		<div class="site-frame">
+			<div class="global-hero-strip mb-3">
+				<a aria-current={Astro.url.pathname === "/" ? "page" : false} class="home-top-image-link" href="/">
+					<img alt="top banner" class="home-top-image" src={homeConfig.topBannerImage} />
+				</a>
+				<div class="home-marquee"><span>{homeConfig.marqueeText}</span></div>
+			</div>
+			{!isHome && <Header />}
+			<main id="main">
+				<slot />
+			</main>
+			<Footer />
+		</div>
 		<div aria-hidden="true" id="global-lightbox">
 			<img alt="Enlarged image" id="global-lightbox-image" src="" />
 		</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,15 +22,8 @@ const daysSinceLastCommit = (() => {
 ---
 
 <PageLayout meta={{ title: "Home" }}>
-	<section class="home-top-strip">
-		<a href="/" class="home-top-image-link">
-			<img alt="top banner" class="home-top-image" src={homeConfig.topBannerImage} />
-		</a>
-		<div class="home-marquee"><span>{homeConfig.marqueeText}</span></div>
-	</section>
-
-	<section class="grid gap-0 lg:grid-cols-[1fr_1.4fr] home-win-grid">
-		<div class="space-y-0">
+	<section class="grid lg:grid-cols-[1fr_1.4fr] home-main-grid" id="home-main-grid">
+		<div class="home-column" id="home-left-column">
 			<section class="win-card">
 				<div class="win-title-bar"><span>WELCOME.EXE</span><span class="win-title-controls"><i></i><i></i></span></div>
 				<div class="win-body">
@@ -59,9 +52,10 @@ const daysSinceLastCommit = (() => {
 				<div class="win-title-bar"><span>GUESTBOOK.TXT</span><span class="win-title-controls"><i></i><i></i></span></div>
 				<div class="win-body text-sm card-enter-wrap"><span>Leave a footprint.</span><span class="win-enter-btn">ENTER</span></div>
 			</a>
+			<div aria-hidden="true" class="home-column-filler hidden" id="home-left-filler">(๑˃ᴗ˂)ﻭ ✧</div>
 		</div>
 
-		<div class="space-y-0">
+		<div class="home-column" id="home-right-column">
 			<section class="win-card">
 				<div class="win-title-bar"><span>README.MD</span><span class="win-title-controls"><i></i><i></i></span></div>
 				<div class="win-body">
@@ -102,6 +96,7 @@ const daysSinceLastCommit = (() => {
 					</div>
 				</div>
 			</a>
+			<div aria-hidden="true" class="home-column-filler hidden" id="home-right-filler">(｡•̀ᴗ-)✧</div>
 		</div>
 	</section>
 </PageLayout>
@@ -111,6 +106,7 @@ const daysSinceLastCommit = (() => {
 	const statusCafeAtomUrl = _statusCafeAtomUrl;
 	const statusImages = _statusImages;
 	const qinhuangdao = { lat: 39.9354, lon: 119.5996 };
+	const statusProxyUrl = (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
 	const haversineKm = (lat1, lon1, lat2, lon2) => {
 		const toRad = (deg) => (deg * Math.PI) / 180;
 		const earthRadiusKm = 6371;
@@ -126,6 +122,42 @@ const daysSinceLastCommit = (() => {
 		if (!content || Number.isNaN(new Date(updated).valueOf())) return null;
 		return { updated, content };
 	}).filter(Boolean);
+
+	const fetchStatusFeedText = async () => {
+		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`;
+		const direct = await fetch(feedUrl, { cache: "no-store" }).catch(() => null);
+		if (direct?.ok) return direct.text();
+		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" });
+		if (!viaProxy.ok) throw new Error("status feed unavailable");
+		return viaProxy.text();
+	};
+
+	const syncHomeColumnsBottom = () => {
+		const leftColumn = document.getElementById("home-left-column");
+		const rightColumn = document.getElementById("home-right-column");
+		const leftFiller = document.getElementById("home-left-filler");
+		const rightFiller = document.getElementById("home-right-filler");
+		if (!leftColumn || !rightColumn || !leftFiller || !rightFiller || window.innerWidth < 1024) {
+			leftFiller?.classList.add("hidden");
+			rightFiller?.classList.add("hidden");
+			return;
+		}
+		leftFiller.classList.add("hidden");
+		rightFiller.classList.add("hidden");
+		leftFiller.style.minHeight = "0px";
+		rightFiller.style.minHeight = "0px";
+		const leftHeight = leftColumn.offsetHeight;
+		const rightHeight = rightColumn.offsetHeight;
+		const gap = Math.abs(leftHeight - rightHeight);
+		if (gap < 6) return;
+		if (leftHeight < rightHeight) {
+			leftFiller.style.minHeight = `${gap}px`;
+			leftFiller.classList.remove("hidden");
+		} else {
+			rightFiller.style.minHeight = `${gap}px`;
+			rightFiller.classList.remove("hidden");
+		}
+	};
 
 	const initHomeHero = () => {
 		const typingTarget = document.getElementById("home-typing");
@@ -169,9 +201,7 @@ const daysSinceLastCommit = (() => {
 		const textEl = document.getElementById("home-status-content");
 		if (!dateEl || !textEl) return;
 		try {
-			const res = await fetch(`${statusCafeAtomUrl}?t=${Date.now()}`, { cache: "no-store" });
-			if (!res.ok) return;
-			const latest = parseStatusFeed(await res.text())[0];
+			const latest = parseStatusFeed(await fetchStatusFeedText())[0];
 			if (!latest) return;
 			dateEl.textContent = new Date(latest.updated).toLocaleString("zh-CN");
 			textEl.textContent = latest.content;
@@ -188,10 +218,14 @@ const daysSinceLastCommit = (() => {
 			});
 		}
 	};
+
 	document.addEventListener("astro:page-load", () => {
 		initHomeHero();
 		initHomeStatus();
+		syncHomeColumnsBottom();
+		window.addEventListener("resize", syncHomeColumnsBottom, { passive: true });
 	});
 	initHomeHero();
 	initHomeStatus();
+	setTimeout(syncHomeColumnsBottom, 120);
 </script>

--- a/src/pages/memos/[...page].astro
+++ b/src/pages/memos/[...page].astro
@@ -2,6 +2,7 @@
 import type { GetStaticPaths, Page } from "astro";
 import Note from "@/components/note/Note.astro";
 import Pagination from "@/components/Paginator.astro";
+import Waline from "@/components/Waline.astro";
 import { siteSettings } from "@/settings/site";
 import { getAllNotes } from "@/data/note";
 import PageLayout from "@/layouts/Base.astro";
@@ -14,79 +15,115 @@ export const getStaticPaths = (async ({ paginate }) => {
 const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNotes>>[number]> };
 ---
 
-<PageLayout meta={{ description: "status.cafe", title: "Memos" }}>
-	<div class="mb-8 flex items-center gap-3">
-		<h1 class="title">Memos</h1>
-	</div>
+<PageLayout meta={{ description: "status.cafe + notes stream", title: "Memos" }}>
+	<section class="memos-feed-page">
+		<header class="memos-feed-header">
+			<h1 class="title">Memos</h1>
+			<p class="text-sm opacity-80">实时信息流：status.cafe + notes</p>
+		</header>
 
-	<section class="mb-8">
-		<h2 class="mb-3 text-sm font-semibold tracking-widest">STATUS CAFE STREAM</h2>
-		<div class="memos-status-grid" id="statuscafe-stream"></div>
-	</section>
+		<section aria-labelledby="status-feed-title" class="memos-feed-section">
+			<h2 class="memos-section-title" id="status-feed-title">STATUS CAFE STREAM</h2>
+			<div class="memos-status-feed" id="statuscafe-stream" role="feed"></div>
+		</section>
 
-	<section>
-		<h2 class="mb-3 text-sm font-semibold tracking-widest">NOTE WATERFALL</h2>
-		<div class="memos-waterfall">
-			{page.data.map((note) => (
-				<div class="memos-waterfall-item"><Note note={note} as="h2" isPreview /></div>
-			))}
-		</div>
+		<section aria-labelledby="note-feed-title" class="memos-feed-section">
+			<h2 class="memos-section-title" id="note-feed-title">NOTES STREAM</h2>
+			<div class="memos-note-feed" role="feed">
+				{page.data.map((note) => (
+					<article class="memos-note-feed-item"><Note note={note} as="h2" isPreview /></article>
+				))}
+			</div>
+		</section>
+
+		<Pagination
+			{...(page.url.prev && { prevUrl: { text: "← Previous Page", url: page.url.prev } })}
+			{...(page.url.next && { nextUrl: { text: "Next Page →", url: page.url.next } })}
+		/>
+
+		<section class="memos-comments-section">
+			<h2 class="memos-section-title">COMMENTS</h2>
+			<Waline path={Astro.url.pathname} />
+		</section>
 	</section>
-	<Pagination
-		{...(page.url.prev && { prevUrl: { text: "← Previous Page", url: page.url.prev } })}
-		{...(page.url.next && { nextUrl: { text: "Next Page →", url: page.url.next } })}
-	/>
 </PageLayout>
 
 <script define:vars={{ statusCafeAtomUrl: siteSettings.statusCafe.atomUrl }} is:inline>
+	const statusProxyUrl = (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
+	const decodeHtmlText = (text) => {
+		const doc = new DOMParser().parseFromString(text, "text/html");
+		return doc.documentElement.textContent ?? "";
+	};
 	const parseStatusFeed = (xmlText) => [...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)].map((entry) => {
 		const body = entry[1] ?? "";
 		const id = body.match(/<id>([\s\S]*?)<\/id>/i)?.[1]?.trim() ?? "";
 		const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? "";
-		const content = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1]?.replace(/&lt;/g, "<")?.replace(/&gt;/g, ">")?.replace(/&amp;/g, "&")?.replace(/<[^>]*>/g, " ")?.replace(/\s+/g, " ")?.trim() ?? "";
+		const contentRaw = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "";
+		const content = decodeHtmlText(contentRaw).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
 		if (!id || !content || Number.isNaN(new Date(updated).valueOf())) return null;
 		return { id, content, updated };
 	}).filter(Boolean);
 
-	const renderAllStatusCafe = async () => {
-		const container = document.getElementById("statuscafe-stream");
-		if (!container) return;
+	const fetchStatusFeedText = async () => {
+		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`;
+		const direct = await fetch(feedUrl, { cache: "no-store" }).catch(() => null);
+		if (direct?.ok) return direct.text();
+		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" });
+		if (!viaProxy.ok) throw new Error("status feed unavailable");
+		return viaProxy.text();
+	};
+
+	const renderStatusFeed = async () => {
+		const statusFeedContainer = document.getElementById("statuscafe-stream");
+		if (!statusFeedContainer) return;
 		try {
-			const res = await fetch(`${statusCafeAtomUrl}?t=${Date.now()}`, { cache: "no-store" });
-			if (!res.ok) return;
-			const items = parseStatusFeed(await res.text());
-			container.innerHTML = items.map((item) => `<article class="status-card"><time class="block text-xs opacity-70">${new Date(item.updated).toLocaleString("zh-CN")}</time><p class="mt-2 whitespace-pre-wrap text-sm">${item.content}</p></article>`).join("");
+			const items = parseStatusFeed(await fetchStatusFeedText());
+			statusFeedContainer.innerHTML = items.map((item) => `<article class="status-card memos-status-feed-item"><time class="block text-xs opacity-70">${new Date(item.updated).toLocaleString("zh-CN")}</time><p class="mt-2 whitespace-pre-wrap text-sm">${item.content}</p></article>`).join("");
 		} catch {
-			container.innerHTML = `<p class="status-card">Unable to load status.cafe stream right now.</p>`;
+			statusFeedContainer.innerHTML = `<p class="status-card">Unable to load status.cafe stream right now.</p>`;
 		}
 	};
 
 	const initStatusStream = () => {
-		renderAllStatusCafe();
+		renderStatusFeed();
 		if (window.__statusStreamTimer) clearInterval(window.__statusStreamTimer);
-		window.__statusStreamTimer = setInterval(renderAllStatusCafe, 45000);
+		window.__statusStreamTimer = setInterval(renderStatusFeed, 45000);
 	};
 	document.addEventListener("astro:page-load", initStatusStream);
 	initStatusStream();
 </script>
 
 <style>
-	.memos-status-grid {
+	.memos-feed-page {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 1rem;
+	}
+
+	.memos-feed-header {
+		display: grid;
+		gap: 0.25rem;
+	}
+
+	.memos-feed-section,
+	.memos-comments-section {
+		display: grid;
+		gap: 0.65rem;
+	}
+
+	.memos-section-title {
+		font-size: 0.8rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+	}
+
+	.memos-status-feed,
+	.memos-note-feed {
+		display: grid;
 		gap: 0.75rem;
 	}
-	.memos-waterfall {
-		column-count: 2;
-		column-gap: 0.9rem;
-	}
-	.memos-waterfall-item {
-		break-inside: avoid;
-		margin-bottom: 0.9rem;
-	}
-	@media (max-width: 640px) {
-		.memos-waterfall {
-			column-count: 1;
-		}
+
+	.memos-status-feed-item,
+	.memos-note-feed-item {
+		border: 2px solid #7e8faa;
 	}
 </style>

--- a/src/pages/memos/[slug].astro
+++ b/src/pages/memos/[slug].astro
@@ -2,6 +2,7 @@
 import { render } from "astro:content";
 import type { GetStaticPaths } from "astro";
 import Note from "@/components/note/Note.astro";
+import Waline from "@/components/Waline.astro";
 import { getAllNotes } from "@/data/note";
 import PageLayout from "@/layouts/Base.astro";
 
@@ -19,5 +20,31 @@ const noteDescription = note.data.description ?? "短博客";
 ---
 
 <PageLayout meta={{ title: note.data.title, description: noteDescription }}>
-	<Note note={note} as="h1" />
+	<section class="memos-note-detail">
+		<Note note={note} as="h1" />
+		<section class="memos-note-comments">
+			<h2 class="memos-note-comments-title">COMMENTS</h2>
+			<Waline path={Astro.url.pathname} />
+		</section>
+	</section>
 </PageLayout>
+
+<style>
+	.memos-note-detail {
+		display: grid;
+		gap: 1rem;
+	}
+
+	.memos-note-comments {
+		border: 2px solid #7e8faa;
+		padding: 0.8rem;
+		background: rgba(220, 232, 248, 0.6);
+	}
+
+	.memos-note-comments-title {
+		font-size: 0.8rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+		margin-bottom: 0.6rem;
+	}
+</style>

--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -2,8 +2,14 @@
     @apply rounded-md px-3 py-2 transition;
 }
 
+.site-frame {
+    border: 2px solid #6f7f99;
+    background: rgba(220, 232, 248, 0.68);
+    padding: 0.55rem;
+}
+
 .win-card {
-    border: 1px solid #7e8faa;
+    border: 2px solid #7e8faa;
     background: #c9d7e8;
     border-radius: 0;
 }
@@ -44,22 +50,21 @@
     color: #2d3a4a;
 }
 
-.home-top-strip {
-    position: sticky;
-    top: 0;
-    z-index: 20;
+.global-hero-strip {
+    position: relative;
+    z-index: 10;
 }
 
 .home-top-image {
     width: 100%;
-    height: 110px;
+    height: 146px;
     object-fit: cover;
-    border: 1px solid #7e8faa;
+    border: 2px solid #7e8faa;
 }
 
 .home-marquee {
     overflow: hidden;
-    border: 1px solid #7e8faa;
+    border: 2px solid #7e8faa;
     border-top: none;
     background: #d5e8fa;
     white-space: nowrap;
@@ -79,6 +84,25 @@
 
 .home-welcome-jump {
     animation: jump 0.7s infinite alternate ease-in-out;
+}
+
+.home-main-grid {
+    gap: 0.8rem;
+}
+
+.home-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.home-column-filler {
+    border: 2px dashed #7e8faa;
+    background: rgba(235, 243, 255, 0.82);
+    color: #4a5b76;
+    font-size: 0.8rem;
+    text-align: center;
+    padding: 0.5rem;
 }
 
 .readme-cover-wrap { position: relative; display: block; }
@@ -137,7 +161,7 @@
 }
 
 .win-nav-wrap {
-    border: 1px solid #7e8faa;
+    border: 2px solid #7e8faa;
     background: #d5e8fa;
     padding: 0.25rem 0.5rem;
 }


### PR DESCRIPTION
### Motivation
- Improve global header alignment and visual consistency by moving the top banner into the shared layout and unifying borders and widths.  
- Make the home layout more robust so left/right columns align at the bottom and avoid unwanted vertical gaps.  
- Provide a reliable, realtime information stream for `memos` that mirrors `status.cafe` and add inline comments for memos.  

### Description
- Moved top banner and marquee into the shared layout `src/layouts/Base.astro` and removed the duplicate banner from `src/components/layout/Header.astro`.  
- Widened the site container (`max-w-6xl`), wrapped page content in a `site-frame` element with a 2px outer border, and upgraded card/nav borders to 2px for consistent alignment via `src/styles/components/homepage.css`.  
- Reworked the homepage grid to `home-main-grid` with column containers `#home-left-column` and `#home-right-column`, added filler placeholders for the shorter column (`home-column-filler`) and JS `syncHomeColumnsBottom()` to auto-balance bottoms in `src/pages/index.astro`.  
- Increased top banner height and adjusted marquee styles in `src/styles/components/homepage.css`, kept the global lightbox in `Base.astro`.  
- Rebuilt the memos listing into a clearer feed structure in `src/pages/memos/[...page].astro` with `STATUS CAFE STREAM`, `NOTES STREAM`, and a `COMMENTS` section, renamed classes to `memos-feed-*` and related variants for clarity.  
- Implemented `status.cafe` fetching fallback logic (direct fetch + proxy via `https://api.allorigins.win`) and periodic refresh (45s) used by both the memos feed and homepage status block; parsing is hardened to decode HTML content safely.  
- Added `Waline` comment integration to the memos list and memo detail pages via `src/components/Waline.astro`, and included a comments block on `src/pages/memos/[slug].astro`.  

### Testing
- Ran `pnpm -s astro check` which completed with 0 errors (only a few TypeScript hints).  
- Ran `pnpm -s build` which completed successfully and produced the static site.  
- Started a dev server and captured visual verification screenshots of the homepage and memos page (screenshots produced during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6b034748832cab74d614763a9db5)