### PR TITLE
Revamp site layout and homepage UX (nav, action rail, memos stream, styles)

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,40 +1,34 @@
 ---
-import Search from "@/components/Search.astro";
-import ThemeToggle from "@/components/ThemeToggle.astro";
-import { homeConfig } from "@/settings/site";
 import { menuLinks } from "@/site.config";
 ---
 
-<header class="mb-8" id="main-header">
-	<div class="home-top-strip mb-3">
-		<a aria-current={Astro.url.pathname === "/" ? "page" : false} class="home-top-image-link" href="/">
-			<img alt="top banner" class="home-top-image" src={homeConfig.topBannerImage} />
-		</a>
-	</div>
-	<div class="win-nav-wrap flex items-center justify-between gap-2">
-		<nav aria-label="Main menu" class="win-nav hidden sm:flex" id="navigation-menu">
-			{menuLinks.map((link, index) =>
-				link.children?.length ? (
-					<div class="relative nav-item-wrap">
-						<button aria-expanded="false" class="card-chip cursor-pointer" data-submenu-toggle={index} type="button">
-							{link.title} ▾
-						</button>
-						<div class="submenu glass-panel absolute left-1/2 top-full z-10 mt-2 hidden min-w-44 -translate-x-1/2 rounded-md p-2">
-							{link.children.map((item) => (
-								<a class="card-chip block" href={item.path}>{item.title}</a>
-							))}
-						</div>
+<header class="mb-6" id="main-header">
+	<nav aria-label="Main menu" class="site-nav-shell" id="navigation-menu">
+		{menuLinks.map((link, index) =>
+			link.children?.length ? (
+				<div class="site-nav-item site-nav-item--submenu">
+					<button aria-expanded="false" class="site-nav-button" data-submenu-toggle={index} type="button">
+						{link.title} ▾
+					</button>
+					<div class="submenu glass-panel site-nav-submenu hidden">
+						{link.children.map((item) => (
+							<a class="site-nav-link" href={item.path}>{item.title}</a>
+						))}
 					</div>
-				) : (
-					<a aria-current={Astro.url.pathname === link.path ? "page" : false} class="card-chip nav-item-wrap" href={link.path} target={link.external ? "_blank" : undefined} rel={link.external ? "noreferrer" : undefined}>{link.title}</a>
-				),
-			)}
-		</nav>
-		<div class="flex items-center gap-2">
-			<Search />
-			<ThemeToggle />
-		</div>
-	</div>
+				</div>
+			) : (
+				<a
+					aria-current={Astro.url.pathname === link.path ? "page" : false}
+					class="site-nav-link site-nav-item"
+					href={link.path}
+					target={link.external ? "_blank" : undefined}
+					rel={link.external ? "noreferrer" : undefined}
+				>
+					{link.title}
+				</a>
+			),
+		)}
+	</nav>
 </header>
 
 <script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,9 +2,11 @@
 import BaseHead from "@/components/BaseHead.astro";
 import Footer from "@/components/layout/Footer.astro";
 import Header from "@/components/layout/Header.astro";
+import Search from "@/components/Search.astro";
 import SkipLink from "@/components/SkipLink.astro";
 import ThemeProvider from "@/components/ThemeProvider.astro";
-import { getPageBackground, siteSettings } from "@/settings/site";
+import ThemeToggle from "@/components/ThemeToggle.astro";
+import { getPageBackground, homeConfig, siteSettings } from "@/settings/site";
 import { siteConfig } from "@/site.config";
 import type { SiteMeta } from "@/types";
 
@@ -24,17 +26,30 @@ const pageBackground = isHome ? siteSettings.backgrounds.home : getPageBackgroun
 		<BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
 	</head>
 	<body
-		class={`bg-global-bg text-global-text mx-auto flex min-h-screen max-w-4xl flex-col bg-cover bg-scroll bg-center px-4 pt-8 text-base font-normal antialiased sm:bg-fixed sm:px-8 sm:pt-16`}
+		class="bg-global-bg text-global-text mx-auto flex min-h-screen w-full max-w-6xl flex-col bg-cover bg-scroll bg-center px-4 pt-8 text-base font-normal antialiased sm:bg-fixed sm:px-8 sm:pt-10"
 		class:list={[isHome && "home-page-bg"]}
-		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${pageBackground});`}
 		data-theme-bg
+		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${pageBackground});`}
 	>
 		<ThemeProvider />
 		<SkipLink />
-		{!isHome && <Header />}
-		<main id="main">
-			<slot />
-		</main>
+		<div class="site-action-rail" role="group" aria-label="Search and theme controls">
+			<Search />
+			<ThemeToggle />
+		</div>
+		<div class="site-content-frame">
+			<div class="site-hero-strip mb-3">
+				<a aria-current={Astro.url.pathname === "/" ? "page" : false} class="home-top-image-link" href="/">
+					<img alt="top banner" class="home-top-image" src={homeConfig.topBannerImage} />
+				</a>
+				<div class="site-hero-kaomoji" aria-hidden="true">❄️ (˶ᵔ ᵕ ᵔ˶) ✦</div>
+				<div class="site-marquee-track"><span>{homeConfig.marqueeText}</span></div>
+			</div>
+			{!isHome && <Header />}
+			<main id="main">
+				<slot />
+			</main>
+		</div>
 		<Footer />
 		<div aria-hidden="true" id="global-lightbox">
 			<img alt="Enlarged image" id="global-lightbox-image" src="" />
@@ -49,6 +64,21 @@ const pageBackground = isHome ? siteSettings.backgrounds.home : getPageBackgroun
 </html>
 
 <script is:inline>
+	const clickFaces = ["❄(◕‿◕)❄", "(ﾉ*･ω･)ﾉ❄", "✧(｡•̀ᴗ-)", "(๑˃ᴗ˂)ﻭ雪", "˗ˏˋ ❄ ˎˊ˗"];
+
+	const showClickKaomoji = (event) => {
+		const target = event.target;
+		if (!(target instanceof Element)) return;
+		if (target.closest("a, button, input, textarea")) return;
+		const effect = document.createElement("span");
+		effect.className = "click-kaomoji-effect";
+		effect.textContent = clickFaces[Math.floor(Math.random() * clickFaces.length)];
+		effect.style.left = `${event.clientX}px`;
+		effect.style.top = `${event.clientY}px`;
+		document.body.append(effect);
+		setTimeout(() => effect.remove(), 900);
+	};
+
 	const bindGlobalLightbox = () => {
 		const lightbox = document.getElementById("global-lightbox");
 		const lightboxImage = document.getElementById("global-lightbox-image");
@@ -79,6 +109,10 @@ const pageBackground = isHome ? siteSettings.backgrounds.home : getPageBackgroun
 					lightbox.setAttribute("aria-hidden", "true");
 				}
 			});
+		}
+		if (document.body.dataset.kaomojiBound !== "1") {
+			document.body.dataset.kaomojiBound = "1";
+			document.addEventListener("pointerdown", showClickKaomoji);
 		}
 	};
 	document.addEventListener("astro:page-load", bindGlobalLightbox);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,9 @@ const gaokao2027 = new Date("2027-06-07T00:00:00+08:00");
 const daysLeft = (targetDate: Date) => Math.max(0, Math.ceil((targetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)));
 const countdownTargetMap = { monthEnd, nextYear, gaokao2027 } as const;
 const countdownItems = homeConfig.countdownTargets.map((item) => ({ ...item, days: daysLeft(countdownTargetMap[item.key]) }));
+const typingText = homeConfig.typingText;
+const statusCafeAtomUrl = homeConfig.statusCafeAtomUrl;
+const statusImages = homeConfig.statusSideImages;
 const daysSinceLastCommit = (() => {
 	try {
 		const last = Number(execSync("git log -1 --format=%ct", { encoding: "utf-8" }).trim()) * 1000;
@@ -22,15 +25,8 @@ const daysSinceLastCommit = (() => {
 ---
 
 <PageLayout meta={{ title: "Home" }}>
-	<section class="home-top-strip">
-		<a href="/" class="home-top-image-link">
-			<img alt="top banner" class="home-top-image" src={homeConfig.topBannerImage} />
-		</a>
-		<div class="home-marquee"><span>{homeConfig.marqueeText}</span></div>
-	</section>
-
-	<section class="grid gap-0 lg:grid-cols-[1fr_1.4fr] home-win-grid">
-		<div class="space-y-0">
+	<section class="grid lg:grid-cols-[1fr_1.4fr] home-layout-grid">
+		<div class="home-layout-column" id="home-left-column">
 			<section class="win-card">
 				<div class="win-title-bar"><span>WELCOME.EXE</span><span class="win-title-controls"><i></i><i></i></span></div>
 				<div class="win-body">
@@ -59,9 +55,10 @@ const daysSinceLastCommit = (() => {
 				<div class="win-title-bar"><span>GUESTBOOK.TXT</span><span class="win-title-controls"><i></i><i></i></span></div>
 				<div class="win-body text-sm card-enter-wrap"><span>Leave a footprint.</span><span class="win-enter-btn">ENTER</span></div>
 			</a>
+			<div aria-hidden="true" class="home-column-filler hidden" id="home-left-filler">❄(◕‿◕)❄</div>
 		</div>
 
-		<div class="space-y-0">
+		<div class="home-layout-column" id="home-right-column">
 			<section class="win-card">
 				<div class="win-title-bar"><span>README.MD</span><span class="win-title-controls"><i></i><i></i></span></div>
 				<div class="win-body">
@@ -71,13 +68,13 @@ const daysSinceLastCommit = (() => {
 					</a>
 					<p class="text-xs opacity-80">Updated {daysSinceLastCommit} days ago.</p>
 					<p class="readme-badges-row">
-						<img alt="C++" src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white" height="25px"/>
-						<img alt="Python" src="https://img.shields.io/badge/Python-14354C?style=for-the-badge&logo=python&logoColor=white" height="25px"/>
-						<img alt="html5" src="https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white" height="25px"/>
-						<img alt="Css3" src="https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white" height="25px"/>
-						<img alt="Javascript" src="https://img.shields.io/badge/JavaScript-323330?style=for-the-badge&logo=javascript&logoColor=F7DF1E"  height="25px"/>
-						<img alt="Nodejs" src="https://img.shields.io/badge/-Nodejs-43853d?style=flat-square&logo=Node.js&logoColor=white"  height="25px"/>
-						<img alt="Astro" src="https://img.shields.io/badge/Astro-0C1222?style=for-the-badge&logo=astro&logoColor=FDFDFE" height="25px"/>
+						<img alt="C++" src="https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white" height="25px" />
+						<img alt="Python" src="https://img.shields.io/badge/Python-14354C?style=for-the-badge&logo=python&logoColor=white" height="25px" />
+						<img alt="html5" src="https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white" height="25px" />
+						<img alt="Css3" src="https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white" height="25px" />
+						<img alt="Javascript" src="https://img.shields.io/badge/JavaScript-323330?style=for-the-badge&logo=javascript&logoColor=F7DF1E" height="25px" />
+						<img alt="Nodejs" src="https://img.shields.io/badge/-Nodejs-43853d?style=flat-square&logo=Node.js&logoColor=white" height="25px" />
+						<img alt="Astro" src="https://img.shields.io/badge/Astro-0C1222?style=for-the-badge&logo=astro&logoColor=FDFDFE" height="25px" />
 					</p>
 					<ul class="mt-4 space-y-2 text-sm">
 						{countdownItems.map((item) => (
@@ -102,15 +99,14 @@ const daysSinceLastCommit = (() => {
 					</div>
 				</div>
 			</a>
+			<div aria-hidden="true" class="home-column-filler hidden" id="home-right-filler">(ﾉ*･ω･)ﾉ❄</div>
 		</div>
 	</section>
 </PageLayout>
 
-<script define:vars={{ _typingText: homeConfig.typingText, _statusCafeAtomUrl: homeConfig.statusCafeAtomUrl, _statusImages: homeConfig.statusSideImages }} is:inline>
-	const typingText = _typingText;
-	const statusCafeAtomUrl = _statusCafeAtomUrl;
-	const statusImages = _statusImages;
+<script define:vars={{ typingText, statusCafeAtomUrl, statusImages }} is:inline>
 	const qinhuangdao = { lat: 39.9354, lon: 119.5996 };
+	const statusProxyUrl = (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
 	const haversineKm = (lat1, lon1, lat2, lon2) => {
 		const toRad = (deg) => (deg * Math.PI) / 180;
 		const earthRadiusKm = 6371;
@@ -127,25 +123,61 @@ const daysSinceLastCommit = (() => {
 		return { updated, content };
 	}).filter(Boolean);
 
+	const fetchStatusFeedText = async () => {
+		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`;
+		const direct = await fetch(feedUrl, { cache: "no-store" }).catch(() => null);
+		if (direct?.ok) return direct.text();
+		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" });
+		if (!viaProxy.ok) throw new Error("status feed unavailable");
+		return viaProxy.text();
+	};
+
+	const syncHomeColumnsBottom = () => {
+		const leftColumn = document.getElementById("home-left-column");
+		const rightColumn = document.getElementById("home-right-column");
+		const leftFiller = document.getElementById("home-left-filler");
+		const rightFiller = document.getElementById("home-right-filler");
+		if (!leftColumn || !rightColumn || !leftFiller || !rightFiller || window.innerWidth < 1024) {
+			leftFiller?.classList.add("hidden");
+			rightFiller?.classList.add("hidden");
+			return;
+		}
+		leftFiller.classList.add("hidden");
+		rightFiller.classList.add("hidden");
+		leftFiller.style.minHeight = "0px";
+		rightFiller.style.minHeight = "0px";
+		const leftHeight = leftColumn.offsetHeight;
+		const rightHeight = rightColumn.offsetHeight;
+		const gap = Math.abs(leftHeight - rightHeight);
+		if (gap < 6) return;
+		if (leftHeight < rightHeight) {
+			leftFiller.style.minHeight = `${gap}px`;
+			leftFiller.classList.remove("hidden");
+		} else {
+			rightFiller.style.minHeight = `${gap}px`;
+			rightFiller.classList.remove("hidden");
+		}
+	};
+
 	const initHomeHero = () => {
 		const typingTarget = document.getElementById("home-typing");
-		let idx = 0;
+		let typingIndex = 0;
 		let deleting = false;
 		if (window.__homeTypingTimer) clearInterval(window.__homeTypingTimer);
 		window.__homeTypingTimer = setInterval(() => {
 			if (!typingTarget) return;
-			typingTarget.textContent = typingText.slice(0, idx).toUpperCase();
+			typingTarget.textContent = typingText.slice(0, typingIndex).toUpperCase();
 			if (!deleting) {
-				idx += 1;
-				if (idx > typingText.length) {
+				typingIndex += 1;
+				if (typingIndex > typingText.length) {
 					deleting = true;
-					idx = typingText.length;
+					typingIndex = typingText.length;
 				}
 			} else {
-				idx -= 1;
-				if (idx < 1) {
+				typingIndex -= 1;
+				if (typingIndex < 1) {
 					deleting = false;
-					idx = 1;
+					typingIndex = 1;
 				}
 			}
 		}, 120);
@@ -169,9 +201,7 @@ const daysSinceLastCommit = (() => {
 		const textEl = document.getElementById("home-status-content");
 		if (!dateEl || !textEl) return;
 		try {
-			const res = await fetch(`${statusCafeAtomUrl}?t=${Date.now()}`, { cache: "no-store" });
-			if (!res.ok) return;
-			const latest = parseStatusFeed(await res.text())[0];
+			const latest = parseStatusFeed(await fetchStatusFeedText())[0];
 			if (!latest) return;
 			dateEl.textContent = new Date(latest.updated).toLocaleString("zh-CN");
 			textEl.textContent = latest.content;
@@ -180,18 +210,22 @@ const daysSinceLastCommit = (() => {
 		}
 		const sideImage = document.getElementById("home-status-side-image");
 		if (sideImage instanceof HTMLImageElement) {
-			let idx = 0;
+			let imageIndex = 0;
 			sideImage.addEventListener("click", (event) => {
 				event.preventDefault();
-				idx = (idx + 1) % statusImages.length;
-				sideImage.src = statusImages[idx];
+				imageIndex = (imageIndex + 1) % statusImages.length;
+				sideImage.src = statusImages[imageIndex];
 			});
 		}
 	};
+
 	document.addEventListener("astro:page-load", () => {
 		initHomeHero();
 		initHomeStatus();
+		syncHomeColumnsBottom();
+		window.addEventListener("resize", syncHomeColumnsBottom, { passive: true });
 	});
 	initHomeHero();
 	initHomeStatus();
+	setTimeout(syncHomeColumnsBottom, 120);
 </script>

--- a/src/pages/memos/[...page].astro
+++ b/src/pages/memos/[...page].astro
@@ -1,10 +1,11 @@
 ---
 import type { GetStaticPaths, Page } from "astro";
-import Note from "@/components/note/Note.astro";
 import Pagination from "@/components/Paginator.astro";
-import { siteSettings } from "@/settings/site";
+import Waline from "@/components/Waline.astro";
+import Note from "@/components/note/Note.astro";
 import { getAllNotes } from "@/data/note";
 import PageLayout from "@/layouts/Base.astro";
+import { siteSettings } from "@/settings/site";
 
 export const getStaticPaths = (async ({ paginate }) => {
 	const notes = await getAllNotes();
@@ -14,78 +15,125 @@ export const getStaticPaths = (async ({ paginate }) => {
 const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNotes>>[number]> };
 ---
 
-<PageLayout meta={{ description: "status.cafe", title: "Memos" }}>
-	<div class="mb-8 flex items-center gap-3">
-		<h1 class="title">Memos</h1>
-	</div>
+<PageLayout meta={{ description: "status.cafe + notes stream", title: "Memos" }}>
+	<section class="memos-page-layout">
+		<header class="memos-page-header">
+			<h1 class="title">Memos</h1>
+			<p class="text-sm opacity-80">实时信息流 + 瀑布流笔记</p>
+		</header>
 
-	<section class="mb-8">
-		<h2 class="mb-3 text-sm font-semibold tracking-widest">STATUS CAFE STREAM</h2>
-		<div class="memos-status-grid" id="statuscafe-stream"></div>
-	</section>
+		<section aria-labelledby="status-feed-title" class="memos-panel-section">
+			<h2 class="memos-panel-title" id="status-feed-title">STATUS CAFE STREAM</h2>
+			<div class="memos-status-stream-grid" id="statuscafe-stream" role="feed"></div>
+		</section>
 
-	<section>
-		<h2 class="mb-3 text-sm font-semibold tracking-widest">NOTE WATERFALL</h2>
-		<div class="memos-waterfall">
-			{page.data.map((note) => (
-				<div class="memos-waterfall-item"><Note note={note} as="h2" isPreview /></div>
-			))}
-		</div>
+		<section aria-labelledby="note-waterfall-title" class="memos-panel-section">
+			<h2 class="memos-panel-title" id="note-waterfall-title">NOTE WATERFALL</h2>
+			<div class="memos-note-waterfall" role="feed">
+				{page.data.map((note) => (
+					<article class="memos-note-waterfall-item"><Note note={note} as="h2" isPreview /></article>
+				))}
+			</div>
+		</section>
+
+		<Pagination
+			{...(page.url.prev && { prevUrl: { text: "← Previous Page", url: page.url.prev } })}
+			{...(page.url.next && { nextUrl: { text: "Next Page →", url: page.url.next } })}
+		/>
+
+		<section class="memos-panel-section">
+			<h2 class="memos-panel-title">COMMENTS</h2>
+			<Waline path={Astro.url.pathname} />
+		</section>
 	</section>
-	<Pagination
-		{...(page.url.prev && { prevUrl: { text: "← Previous Page", url: page.url.prev } })}
-		{...(page.url.next && { nextUrl: { text: "Next Page →", url: page.url.next } })}
-	/>
 </PageLayout>
 
 <script define:vars={{ statusCafeAtomUrl: siteSettings.statusCafe.atomUrl }} is:inline>
+	const statusProxyUrl = (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
+	const decodeHtmlText = (text) => {
+		const doc = new DOMParser().parseFromString(text, "text/html");
+		return doc.documentElement.textContent ?? "";
+	};
 	const parseStatusFeed = (xmlText) => [...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)].map((entry) => {
 		const body = entry[1] ?? "";
 		const id = body.match(/<id>([\s\S]*?)<\/id>/i)?.[1]?.trim() ?? "";
 		const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? "";
-		const content = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1]?.replace(/&lt;/g, "<")?.replace(/&gt;/g, ">")?.replace(/&amp;/g, "&")?.replace(/<[^>]*>/g, " ")?.replace(/\s+/g, " ")?.trim() ?? "";
+		const contentRaw = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "";
+		const content = decodeHtmlText(contentRaw).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
 		if (!id || !content || Number.isNaN(new Date(updated).valueOf())) return null;
 		return { id, content, updated };
 	}).filter(Boolean);
 
-	const renderAllStatusCafe = async () => {
-		const container = document.getElementById("statuscafe-stream");
-		if (!container) return;
+	const fetchStatusFeedText = async () => {
+		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`;
+		const direct = await fetch(feedUrl, { cache: "no-store" }).catch(() => null);
+		if (direct?.ok) return direct.text();
+		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" });
+		if (!viaProxy.ok) throw new Error("status feed unavailable");
+		return viaProxy.text();
+	};
+
+	const renderStatusFeed = async () => {
+		const statusFeedContainer = document.getElementById("statuscafe-stream");
+		if (!statusFeedContainer) return;
 		try {
-			const res = await fetch(`${statusCafeAtomUrl}?t=${Date.now()}`, { cache: "no-store" });
-			if (!res.ok) return;
-			const items = parseStatusFeed(await res.text());
-			container.innerHTML = items.map((item) => `<article class="status-card"><time class="block text-xs opacity-70">${new Date(item.updated).toLocaleString("zh-CN")}</time><p class="mt-2 whitespace-pre-wrap text-sm">${item.content}</p></article>`).join("");
+			const items = parseStatusFeed(await fetchStatusFeedText());
+			statusFeedContainer.innerHTML = items.map((item) => `<article class="status-card memos-status-stream-item"><time class="block text-xs opacity-70">${new Date(item.updated).toLocaleString("zh-CN")}</time><p class="mt-2 whitespace-pre-wrap text-sm">${item.content}</p></article>`).join("");
 		} catch {
-			container.innerHTML = `<p class="status-card">Unable to load status.cafe stream right now.</p>`;
+			statusFeedContainer.innerHTML = `<p class="status-card">Unable to load status.cafe stream right now.</p>`;
 		}
 	};
 
 	const initStatusStream = () => {
-		renderAllStatusCafe();
+		renderStatusFeed();
 		if (window.__statusStreamTimer) clearInterval(window.__statusStreamTimer);
-		window.__statusStreamTimer = setInterval(renderAllStatusCafe, 45000);
+		window.__statusStreamTimer = setInterval(renderStatusFeed, 45000);
 	};
 	document.addEventListener("astro:page-load", initStatusStream);
 	initStatusStream();
 </script>
 
 <style>
-	.memos-status-grid {
+	.memos-page-layout {
+		display: grid;
+		gap: 1rem;
+	}
+
+	.memos-page-header,
+	.memos-panel-section {
+		display: grid;
+		gap: 0.65rem;
+	}
+
+	.memos-panel-title {
+		font-size: 0.8rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+	}
+
+	.memos-status-stream-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 		gap: 0.75rem;
 	}
-	.memos-waterfall {
+
+	.memos-note-waterfall {
 		column-count: 2;
-		column-gap: 0.9rem;
+		column-gap: 0.8rem;
 	}
-	.memos-waterfall-item {
+
+	.memos-note-waterfall-item {
 		break-inside: avoid;
-		margin-bottom: 0.9rem;
+		margin-bottom: 0.8rem;
+		border: 2px solid #7e8faa;
 	}
+
+	.memos-status-stream-item {
+		border: 2px solid #7e8faa;
+	}
+
 	@media (max-width: 640px) {
-		.memos-waterfall {
+		.memos-note-waterfall {
 			column-count: 1;
 		}
 	}

--- a/src/pages/memos/[slug].astro
+++ b/src/pages/memos/[slug].astro
@@ -2,6 +2,7 @@
 import { render } from "astro:content";
 import type { GetStaticPaths } from "astro";
 import Note from "@/components/note/Note.astro";
+import Waline from "@/components/Waline.astro";
 import { getAllNotes } from "@/data/note";
 import PageLayout from "@/layouts/Base.astro";
 
@@ -19,5 +20,37 @@ const noteDescription = note.data.description ?? "短博客";
 ---
 
 <PageLayout meta={{ title: note.data.title, description: noteDescription }}>
-	<Note note={note} as="h1" />
+	<section class="memos-note-detail">
+		<Note note={note} as="h1" />
+		<section class="memos-note-comments">
+			<h2 class="memos-note-comments-title">COMMENTS</h2>
+			<Waline path={Astro.url.pathname} />
+		</section>
+	</section>
 </PageLayout>
+
+<style>
+	.memos-note-detail {
+		display: grid;
+		gap: 1rem;
+	}
+
+	.memos-note-comments {
+		border: 2px solid #7e8faa;
+		padding: 0.8rem;
+		background: rgba(220, 232, 248, 0.6);
+	}
+
+	.memos-note-comments-title {
+		font-size: 0.8rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+		margin-bottom: 0.6rem;
+	}
+
+	.dark .memos-note-comments,
+	[data-theme="dark"] .memos-note-comments {
+		background: rgba(46, 61, 89, 0.72);
+		border-color: #96abcf;
+	}
+</style>

--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -1,161 +1,321 @@
 .card-chip {
-    @apply rounded-md px-3 py-2 transition;
+	@apply rounded-md px-3 py-2 transition;
+}
+
+.site-content-frame {
+	border: 2px solid #6f7f99;
+	background: rgba(220, 232, 248, 0.74);
+	padding: 0.55rem;
+}
+
+.site-hero-strip {
+	position: relative;
+	z-index: 10;
+}
+
+.site-hero-kaomoji {
+	position: absolute;
+	right: 0.65rem;
+	top: 0.55rem;
+	font-size: 0.8rem;
+	padding: 0.2rem 0.45rem;
+	background: rgba(255, 255, 255, 0.7);
+	border: 1px dashed #7e8faa;
+}
+
+.home-top-image {
+	width: 100%;
+	height: 146px;
+	object-fit: cover;
+	border: 2px solid #7e8faa;
+}
+
+.site-marquee-track {
+	overflow: hidden;
+	border: 2px solid #7e8faa;
+	border-top: none;
+	background: #d5e8fa;
+	white-space: nowrap;
+}
+
+.site-marquee-track span {
+	display: inline-block;
+	padding-left: 100%;
+	animation: home-marquee 20s linear infinite;
+	font-size: 0.75rem;
+}
+
+@keyframes home-marquee {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(-100%);
+	}
 }
 
 .win-card {
-    border: 1px solid #7e8faa;
-    background: #c9d7e8;
-    border-radius: 0;
+	border: 2px solid #7e8faa;
+	background: #c9d7e8;
+	border-radius: 0;
 }
 
 .win-title-bar {
-    background: linear-gradient(90deg, #4c557a, #b0bdcf);
-    color: #fff;
-    font-size: 0.75rem;
-    letter-spacing: 0.06em;
-    padding: 0.35rem 0.55rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+	background: linear-gradient(90deg, #4c557a, #b0bdcf);
+	color: #fff;
+	font-size: 0.75rem;
+	letter-spacing: 0.06em;
+	padding: 0.35rem 0.55rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .win-title-controls {
-    display: inline-flex;
-    gap: 0.25rem;
+	display: inline-flex;
+	gap: 0.25rem;
 }
 
 .win-title-controls i {
-    width: 10px;
-    height: 10px;
-    border: 1px solid #dce5ff;
-    background: #8fa0bf;
-    display: inline-block;
+	width: 10px;
+	height: 10px;
+	border: 1px solid #dce5ff;
+	background: #8fa0bf;
+	display: inline-block;
 }
 
 .win-body {
-    color: #2d3a4a;
-    padding: 0.8rem;
+	color: #2d3a4a;
+	padding: 0.8rem;
+}
+
+.home-welcome-jump {
+	animation: jump 0.7s infinite alternate ease-in-out;
+}
+
+.home-layout-grid {
+	column-gap: 0.9rem;
+	row-gap: 0;
+}
+
+.home-layout-column {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+}
+
+.home-layout-column > * + * {
+	margin-top: 0;
+}
+
+.home-column-filler {
+	border: 2px dashed #7e8faa;
+	background: rgba(235, 243, 255, 0.9);
+	color: #4a5b76;
+	font-size: 0.8rem;
+	text-align: center;
+	padding: 0.5rem;
+}
+
+.readme-cover-wrap {
+	position: relative;
+	display: block;
+}
+
+.readme-corner-image {
+	width: 80px;
+	height: 80px;
+	object-fit: cover;
+	position: absolute;
+	right: 0.5rem;
+	bottom: 0.5rem;
+	border: 1px solid #7e8faa;
+}
+
+.readme-badges-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25rem;
+	margin-top: 0.5rem;
+}
+
+.status-split {
+	display: grid;
+	grid-template-columns: 1.7fr 1fr;
+	gap: 0.75rem;
+}
+
+.status-split > div:first-child {
+	border-right: 1px dashed #7e8faa;
+	padding-right: 0.75rem;
+}
+
+.status-side-image-wrap img {
+	width: 100%;
+	cursor: pointer;
+	border: 1px solid #7e8faa;
+}
+
+.win-enter-btn {
+	border: 1px solid #7e8faa;
+	background: #e8f2ff;
+	padding: 0.2rem 0.6rem;
+	font-size: 0.75rem;
+}
+
+.card-enter-wrap {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+}
+
+.memo-card-mini {
+	width: 44px;
+	height: 44px;
+	margin-left: auto;
+}
+
+.site-nav-shell {
+	border: 2px solid #7e8faa;
+	background: #d5e8fa;
+	padding: 0.45rem;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+.site-nav-item {
+	position: relative;
+}
+
+.site-nav-link,
+.site-nav-button {
+	border: 1px solid #7e8faa;
+	background: #edf4ff;
+	padding: 0.25rem 0.6rem;
+	font-size: 0.8rem;
+	line-height: 1.2;
+}
+
+.site-nav-submenu {
+	position: absolute;
+	left: 50%;
+	top: 100%;
+	z-index: 10;
+	margin-top: 0.3rem;
+	min-width: 11rem;
+	transform: translateX(-50%);
+	border: 2px solid #7e8faa;
+	padding: 0.4rem;
+	display: grid;
+	gap: 0.25rem;
+}
+
+.site-action-rail {
+	position: fixed;
+	top: 1rem;
+	right: max(0.75rem, calc((100vw - 96rem) / 2 + 0.75rem));
+	z-index: 80;
+	display: grid;
+	gap: 0.4rem;
+}
+
+.site-action-rail > * {
+	border: 2px solid #7e8faa;
+	background: rgba(220, 232, 248, 0.9);
+	padding: 0.25rem;
+}
+
+.click-kaomoji-effect {
+	position: fixed;
+	z-index: 999;
+	pointer-events: none;
+	font-size: 0.8rem;
+	color: #3a5066;
+	text-shadow: 0 0 4px #fff;
+	transform: translate(-50%, -50%);
+	animation: kaomoji-pop 0.9s ease-out forwards;
+}
+
+@keyframes kaomoji-pop {
+	0% {
+		opacity: 0;
+		transform: translate(-50%, -50%) scale(0.8);
+	}
+	20% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+		transform: translate(-50%, -160%) scale(1.25);
+	}
+}
+
+.dark .site-content-frame,
+[data-theme="dark"] .site-content-frame {
+	background: rgba(33, 43, 61, 0.84);
+	border-color: #96abcf;
+}
+
+.dark .win-card,
+[data-theme="dark"] .win-card {
+	background: #2d3d5a;
+	border-color: #96abcf;
+}
+
+.dark .win-title-bar,
+[data-theme="dark"] .win-title-bar {
+	background: linear-gradient(90deg, #637293, #96abcf);
 }
 
 .dark .win-body,
 [data-theme="dark"] .win-body,
 .dark .win-body a,
-[data-theme="dark"] .win-body a {
-    color: #2d3a4a;
+[data-theme="dark"] .win-body a,
+.dark .status-card,
+[data-theme="dark"] .status-card {
+	color: #eaf2ff;
 }
 
-.home-top-strip {
-    position: sticky;
-    top: 0;
-    z-index: 20;
+.dark .site-marquee-track,
+[data-theme="dark"] .site-marquee-track,
+.dark .site-nav-shell,
+[data-theme="dark"] .site-nav-shell,
+.dark .site-nav-link,
+[data-theme="dark"] .site-nav-link,
+.dark .site-nav-button,
+[data-theme="dark"] .site-nav-button,
+.dark .site-action-rail > *,
+[data-theme="dark"] .site-action-rail > * {
+	background: #30415f;
+	color: #eef5ff;
+	border-color: #96abcf;
 }
 
-.home-top-image {
-    width: 100%;
-    height: 110px;
-    object-fit: cover;
-    border: 1px solid #7e8faa;
-}
-
-.home-marquee {
-    overflow: hidden;
-    border: 1px solid #7e8faa;
-    border-top: none;
-    background: #d5e8fa;
-    white-space: nowrap;
-}
-
-.home-marquee span {
-    display: inline-block;
-    padding-left: 100%;
-    animation: home-marquee 20s linear infinite;
-    font-size: 0.75rem;
-}
-
-@keyframes home-marquee {
-    from { transform: translateX(0); }
-    to { transform: translateX(-100%); }
-}
-
-.home-welcome-jump {
-    animation: jump 0.7s infinite alternate ease-in-out;
-}
-
-.readme-cover-wrap { position: relative; display: block; }
-.readme-corner-image {
-    width: 80px;
-    height: 80px;
-    object-fit: cover;
-    position: absolute;
-    right: 0.5rem;
-    bottom: 0.5rem;
-    border: 1px solid #7e8faa;
-}
-
-.readme-badges-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    margin-top: 0.5rem;
-}
-
-.status-split {
-    display: grid;
-    grid-template-columns: 1.7fr 1fr;
-    gap: 0.75rem;
-}
-
-.status-split > div:first-child {
-    border-right: 1px dashed #7e8faa;
-    padding-right: 0.75rem;
-}
-
-.status-side-image-wrap img {
-    width: 100%;
-    cursor: pointer;
-    border: 1px solid #7e8faa;
-}
-
-.win-enter-btn {
-    border: 1px solid #7e8faa;
-    background: #e8f2ff;
-    padding: 0.2rem 0.6rem;
-    font-size: 0.75rem;
-}
-
-.card-enter-wrap {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-}
-
-.memo-card-mini {
-    width: 44px;
-    height: 44px;
-    margin-left: auto;
-}
-
-.win-nav-wrap {
-    border: 1px solid #7e8faa;
-    background: #d5e8fa;
-    padding: 0.25rem 0.5rem;
-}
-
-.win-nav {
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-    max-width: 70%;
-}
-
-.nav-item-wrap {
-    position: relative;
-}
-
-.nav-item-wrap + .nav-item-wrap::before {
-    content: "";
-    border-left: 1px dashed #7e8faa;
-    margin-right: 0.5rem;
-    padding-left: 0.5rem;
+@media (max-width: 640px) {
+	.site-hero-kaomoji {
+		font-size: 0.72rem;
+	}
+	.site-action-rail {
+		top: auto;
+		bottom: 0.8rem;
+		right: 0.55rem;
+	}
+	.site-nav-submenu {
+		position: static;
+		transform: none;
+		margin-top: 0.2rem;
+	}
+	.status-split {
+		grid-template-columns: 1fr;
+	}
+	.status-split > div:first-child {
+		border-right: 0;
+		padding-right: 0;
+		padding-bottom: 0.5rem;
+		border-bottom: 1px dashed #7e8faa;
+	}
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,13 +6,14 @@
 
 @theme {
 	--color-global-bg: oklch(96% 0.018 220);
-	--color-global-text: oklch(34% 0.03 232);
+	--color-global-text: oklch(30% 0.032 232);
 	--color-link: oklch(52% 0.085 220);
 	--color-accent: oklch(60% 0.09 218);
 	--color-accent-2: oklch(38% 0.045 232);
 	--color-quote: oklch(48% 0.055 220);
 	--color-bg-overlay: rgba(236, 245, 248, 0.78);
 	--color-surface: rgba(255, 255, 255, 0.7);
+	--color-surface-dark: rgba(33, 45, 66, 0.82);
 }
 
 @layer base {
@@ -100,7 +101,13 @@
 		@apply rounded-md px-4 py-3;
 		background: var(--color-surface);
 		backdrop-filter: blur(6px);
-	}	
+	}
+
+	.dark .status-card,
+	[data-theme="dark"] .status-card {
+		background: var(--color-surface-dark);
+		color: #edf4ff;
+	}
 }
 
 @keyframes jump {


### PR DESCRIPTION
### Motivation
- Modernize the site frame and homepage visuals to centralize hero/banner, move search/theme controls into a fixed action rail, and provide a more cohesive site surface and marquee area.
- Simplify and restyle the primary navigation and submenu markup for consistent classes and easier theming.
- Enhance the memos pages by adding a live status.cafe stream, a note waterfall layout, and comments via `Waline`.
- Improve UX touches such as typing hero animation, responsive column height sync, status feed proxy fallback, click-kaomoji effects, and dark-mode surface adjustments.

### Description
- Reworked `src/components/layout/Header.astro` to use new `site-nav-*` classes and simplified submenu DOM structure, removing in-header search and theme controls.
- Updated `src/layouts/Base.astro` to introduce a `site-action-rail` (fixed search and `ThemeToggle`), wrap page content in `site-content-frame`, add a hero/banner strip using `homeConfig`, and register a `showClickKaomoji` pointer effect for small UI animations.
- Overhauled `src/pages/index.astro` to a two-column home layout, moved hero/banner into the base layout, added typed-hero logic (renamed variables), introduced `fetchStatusFeedText` with proxy fallback, implemented `syncHomeColumnsBottom` to balance column bottoms, and improved image cycling logic for the status card.
- Rebuilt `src/pages/memos/[...page].astro` and `src/pages/memos/[slug].astro` to add a `Waline` comments component, restructure the memos page into feed and waterfall sections, decode status feed HTML safely, add proxy fallback fetching, and add new layout/styling for memos and comment areas.
- Large CSS updates in `src/styles/components/homepage.css` and `src/styles/global.css` to add `site-` prefixed components, marquee animation, action-rail and kaomoji styles, updated card borders/backgrounds, and dark-theme surface fixes.

### Testing
- No automated test suite was added or executed as part of this change set.
- Manual local verification was performed during development to confirm layout rendering, menu submenu toggles, typing hero, status feed fetch fallback, and comment widget integration (not an automated test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6b034748832cab74d614763a9db5)