### PR TITLE
Redesign layout: shared left sidebar, 3-column homepage, grouped memos, and typography tweaks

### DIFF
--- a/src/components/layout/SharedLeftSidebar.astro
+++ b/src/components/layout/SharedLeftSidebar.astro
@@ -1,0 +1,42 @@
+---
+import { homeConfig } from "@/settings/site";
+
+interface Props {
+	compact?: boolean;
+}
+
+const { compact = false } = Astro.props;
+---
+
+<aside
+	class="home-sidebar-frame home-layout-column shared-left-sidebar"
+	data-compact={compact ? "1" : "0"}
+>
+	<section class="win-card">
+		<div class="win-title-bar">
+			<span>WELCOME.EXE</span><span class="win-title-controls"><i></i><i></i></span>
+		</div>
+		<div class="win-body">
+			<h2 class="title mb-2 text-xl">Eucaly's Blog</h2>
+			<p class="text-sm opacity-85">A tiny blue corner for posts, memos, and media.</p>
+		</div>
+	</section>
+	<div class="angel-divider" aria-hidden="true">°‧🪽₊⋆༺✧༻⋆₊🪽‧°</div>
+
+	<a class="home-plain-card block" href="/posts/">
+		<div class="card-enter-wrap text-sm">
+			<span>Read posts archive.</span><span class="win-enter-btn">ENTER</span>
+		</div>
+	</a>
+	<a class="home-plain-card block" href="/memos/">
+		<div class="card-enter-wrap text-sm">
+			<span>Open memos stream.</span><span class="win-enter-btn">ENTER</span>
+		</div>
+	</a>
+	<a class="home-plain-card block" href="/gallery/">
+		<div class="card-enter-wrap text-sm">
+			<span>Visit gallery zone.</span><span class="win-enter-btn">ENTER</span>
+		</div>
+		<img alt="gallery entry" class="home-card-image" src={homeConfig.galleryCardImage} />
+	</a>
+</aside>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,7 +1,7 @@
 ---
 import BaseHead from "@/components/BaseHead.astro";
 import Footer from "@/components/layout/Footer.astro";
-import Header from "@/components/layout/Header.astro";
+import SharedLeftSidebar from "@/components/layout/SharedLeftSidebar.astro";
 import Search from "@/components/Search.astro";
 import SkipLink from "@/components/SkipLink.astro";
 import ThemeProvider from "@/components/ThemeProvider.astro";
@@ -18,6 +18,8 @@ const {
 	meta: { articleDate, description = siteConfig.description, ogImage, title },
 } = Astro.props;
 const isHome = Astro.url.pathname === "/";
+const isAbout = Astro.url.pathname === "/about/";
+const useSharedLeftSidebar = !isHome && !isAbout;
 const pageBackground = isHome
 	? siteSettings.backgrounds.home
 	: getPageBackground(Astro.url.pathname);
@@ -28,7 +30,7 @@ const pageBackground = isHome
 		<BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
 	</head>
 	<body
-		class="bg-global-bg text-global-text mx-auto flex min-h-screen w-full max-w-5xl flex-col bg-cover bg-scroll bg-center px-3 pt-6 text-base font-normal antialiased sm:bg-fixed sm:px-6 sm:pt-8"
+		class="bg-global-bg text-global-text mx-auto flex min-h-screen w-full max-w-6xl flex-col bg-cover bg-scroll bg-center px-3 pt-6 text-base font-normal antialiased sm:bg-fixed sm:px-6 sm:pt-8"
 		class:list={[isHome && "home-page-bg"]}
 		data-theme-bg
 		style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${pageBackground});`}
@@ -51,9 +53,19 @@ const pageBackground = isHome
 				<div class="site-hero-kaomoji" aria-hidden="true">❄️ (˶ᵔ ᵕ ᵔ˶) ✦</div>
 				<div class="site-marquee-track"><span>{homeConfig.marqueeText}</span></div>
 			</div>
-			{!isHome && <Header />}
 			<main id="main">
-				<slot />
+				{
+					useSharedLeftSidebar ? (
+						<section class="inner-page-shell">
+							<SharedLeftSidebar compact />
+							<div class="inner-page-content">
+								<slot />
+							</div>
+						</section>
+					) : (
+						<slot />
+					)
+				}
 			</main>
 		</div>
 		<Footer />
@@ -71,6 +83,14 @@ const pageBackground = isHome
 
 <script is:inline>
 	const clickFaces = ["❄(◕‿◕)❄", "(ﾉ*･ω･)ﾉ❄", "✧(｡•̀ᴗ-)", "(๑˃ᴗ˂)ﻭ雪", "˗ˏˋ ❄ ˎˊ˗"];
+	const quotes = [
+		"The only true wisdom is in knowing you know nothing. — Socrates",
+		"Simplicity is the ultimate sophistication. — Leonardo da Vinci",
+		"Stay hungry, stay foolish. — Steve Jobs",
+		"We are what we repeatedly do. — Aristotle",
+		"The future depends on what we do in the present. — Gandhi",
+	];
+	const quoteColors = ["#1d4ed8", "#1e40af", "#2563eb", "#3b82f6", "#0f52ba"];
 
 	const showClickKaomoji = (event) => {
 		const target = event.target;
@@ -121,6 +141,19 @@ const pageBackground = isHome
 			document.addEventListener("pointerdown", showClickKaomoji);
 		}
 	};
+
+	const initMarqueeQuote = () => {
+		const marquee = document.querySelector(".site-marquee-track span");
+		if (!(marquee instanceof HTMLElement)) return;
+		const quote = quotes[Math.floor(Math.random() * quotes.length)];
+		marquee.textContent = quote;
+		if (window.__quoteColorTimer) clearInterval(window.__quoteColorTimer);
+		window.__quoteColorTimer = setInterval(() => {
+			marquee.style.color = quoteColors[Math.floor(Math.random() * quoteColors.length)];
+		}, 1300);
+	};
 	document.addEventListener("astro:page-load", bindGlobalLightbox);
+	document.addEventListener("astro:page-load", initMarqueeQuote);
 	bindGlobalLightbox();
+	initMarqueeQuote();
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { execSync } from "node:child_process";
+import SharedLeftSidebar from "@/components/layout/SharedLeftSidebar.astro";
 import { homeConfig } from "@/settings/site";
 import PageLayout from "@/layouts/Base.astro";
 
@@ -30,10 +31,12 @@ const daysSinceLastCommit = (() => {
 
 <PageLayout meta={{ title: "Home" }}>
 	<section class="home-main-grid">
-		<div class="home-sidebar-frame home-layout-column" id="home-left-column">
+		<SharedLeftSidebar />
+
+		<div class="home-middle-column">
 			<section class="win-card">
 				<div class="win-title-bar">
-					<span>WELCOME.EXE</span><span class="win-title-controls"><i></i><i></i></span>
+					<span>README.MD</span><span class="win-title-controls"><i></i><i></i></span>
 				</div>
 				<div class="win-body">
 					<h1 class="title mb-3" id="home-typing"></h1>
@@ -41,86 +44,62 @@ const daysSinceLastCommit = (() => {
 					<p class="mt-1 text-xs opacity-80" id="home-distance">
 						You are ... km away from An-chan.
 					</p>
+					<p class="mt-4 text-sm opacity-85">
+						这里是主页主栏，已预留多图位置，方便你后续替换贴图。
+					</p>
 				</div>
 			</section>
-			<div class="angel-divider" aria-hidden="true">°‧🪽₊⋆༺✧༻⋆₊🪽‧°</div>
 
-			<a class="home-plain-card block" href="/gallery/">
-				<div class="card-enter-wrap text-sm">
-					<span>Open gallery zone.</span><span class="win-enter-btn">ENTER</span>
-				</div>
-				<img alt="gallery entry" class="home-card-image" src={homeConfig.galleryCardImage} />
-			</a>
-			<div class="angel-divider" aria-hidden="true">°‧🪽₊⋆༺✧༻⋆₊🪽‧°</div>
-
-			<a class="home-plain-card block" href="/notes/">
-				<div class="card-enter-wrap text-sm">
-					<span>Read notes.log.</span><span class="win-enter-btn">ENTER</span>
-				</div>
-			</a>
-			<div aria-hidden="true" class="home-column-filler hidden" id="home-left-filler">❄(◕‿◕)❄</div>
+			<section class="home-image-grid" aria-label="image placeholders">
+				<figure class="home-image-placeholder home-image-placeholder--wide">
+					<span>PLACEHOLDER IMAGE A · banner</span>
+				</figure>
+				<figure class="home-image-placeholder"><span>PLACEHOLDER IMAGE B</span></figure>
+				<figure class="home-image-placeholder"><span>PLACEHOLDER IMAGE C</span></figure>
+				<figure class="home-image-placeholder home-image-placeholder--wide">
+					<span>PLACEHOLDER IMAGE D · story strip</span>
+				</figure>
+			</section>
 		</div>
 
-		<div class="home-sidebar-frame home-layout-column" id="home-right-column">
-			<section class="win-card">
-				<div class="win-title-bar">
-					<span>README.MD</span><span class="win-title-controls"><i></i><i></i></span>
-				</div>
-				<div class="win-body">
-					<a href="/about/" class="readme-cover-wrap">
-						<img
-							alt="readme entry"
-							class="mb-3 w-full rounded-md object-contain"
-							src={homeConfig.profileCoverImage}
-						/>
-						<img
-							alt="corner sticker"
-							class="readme-corner-image"
-							src={homeConfig.readmeCornerImage}
-						/>
-					</a>
-					<p class="text-xs opacity-80">Updated {daysSinceLastCommit} days ago.</p>
-					<ul class="mt-4 space-y-2 text-sm">
-						{
-							countdownItems.map((item) => (
-								<li class="rounded-md border border-black/40 bg-white/70 px-3 py-2 dark:bg-zinc-900/70">
-									<span>{item.label}</span>
-									<strong>
-										{item.days}
-										{item.suffix}
-									</strong>
-								</li>
-							))
-						}
-					</ul>
+		<aside class="home-sidebar-frame home-layout-column home-right-rail">
+			<section class="home-right-card">
+				<h2>Last Update</h2>
+				<p class="text-sm">Updated {daysSinceLastCommit} days ago.</p>
+			</section>
+			<section class="home-right-card">
+				<h2>Countdown</h2>
+				<ul class="space-y-2 text-sm">
+					{
+						countdownItems.map((item) => (
+							<li>
+								{item.label}{" "}
+								<strong>
+									{item.days}
+									{item.suffix}
+								</strong>
+							</li>
+						))
+					}
+				</ul>
+			</section>
+			<section class="home-right-card">
+				<h2>Status.cafe</h2>
+				<time class="text-xs opacity-70" id="home-status-date">Loading...</time>
+				<p class="mt-2 text-sm" id="home-status-content">Syncing status.cafe feed ...</p>
+			</section>
+			<section class="home-right-card">
+				<h2>Side Image</h2>
+				<img alt="status side" id="home-status-side-image" src={homeConfig.statusSideImages[0]} />
+			</section>
+			<section class="home-right-card">
+				<h2>Quick Entry</h2>
+				<div class="card-enter-wrap text-sm">
+					<a class="cactus-link" href="/about/">About</a>
+					<a class="cactus-link" href="/memos/">Memos</a>
 				</div>
 			</section>
-			<div class="angel-divider" aria-hidden="true">°‧🪽₊⋆༺✧༻⋆₊🪽‧°</div>
-
-			<a
-				class="home-plain-card block"
-				href="https://status.cafe/users/isntbunny"
-				target="_blank"
-				rel="noreferrer"
-			>
-				<div class="status-split">
-					<div>
-						<time class="text-xs opacity-70" id="home-status-date">Loading...</time>
-						<p class="mt-2 text-sm" id="home-status-content">Syncing status.cafe feed ...</p>
-					</div>
-					<div class="status-side-image-wrap">
-						<img
-							alt="status side"
-							id="home-status-side-image"
-							src={homeConfig.statusSideImages[0]}
-						/>
-					</div>
-				</div>
-			</a>
-			<div aria-hidden="true" class="home-column-filler hidden" id="home-right-filler">
-				(ﾉ*･ω･)ﾉ❄
-			</div>
-		</div>
+		</aside>
 	</section>
 </PageLayout>
 
@@ -163,33 +142,6 @@ const daysSinceLastCommit = (() => {
 		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" });
 		if (!viaProxy.ok) throw new Error("status feed unavailable");
 		return viaProxy.text();
-	};
-
-	const syncHomeColumnsBottom = () => {
-		const leftColumn = document.getElementById("home-left-column");
-		const rightColumn = document.getElementById("home-right-column");
-		const leftFiller = document.getElementById("home-left-filler");
-		const rightFiller = document.getElementById("home-right-filler");
-		if (!leftColumn || !rightColumn || !leftFiller || !rightFiller || window.innerWidth < 1024) {
-			leftFiller?.classList.add("hidden");
-			rightFiller?.classList.add("hidden");
-			return;
-		}
-		leftFiller.classList.add("hidden");
-		rightFiller.classList.add("hidden");
-		leftFiller.style.minHeight = "0px";
-		rightFiller.style.minHeight = "0px";
-		const leftHeight = leftColumn.offsetHeight;
-		const rightHeight = rightColumn.offsetHeight;
-		const gap = Math.abs(leftHeight - rightHeight);
-		if (gap < 6) return;
-		if (leftHeight < rightHeight) {
-			leftFiller.style.minHeight = `${gap}px`;
-			leftFiller.classList.remove("hidden");
-		} else {
-			rightFiller.style.minHeight = `${gap}px`;
-			rightFiller.classList.remove("hidden");
-		}
 	};
 
 	const initHomeHero = () => {
@@ -266,10 +218,7 @@ const daysSinceLastCommit = (() => {
 	document.addEventListener("astro:page-load", () => {
 		initHomeHero();
 		initHomeStatus();
-		syncHomeColumnsBottom();
-		window.addEventListener("resize", syncHomeColumnsBottom, { passive: true });
 	});
 	initHomeHero();
 	initHomeStatus();
-	setTimeout(syncHomeColumnsBottom, 120);
 </script>

--- a/src/pages/memos/[...page].astro
+++ b/src/pages/memos/[...page].astro
@@ -13,6 +13,21 @@ export const getStaticPaths = (async ({ paginate }) => {
 }) satisfies GetStaticPaths;
 
 const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNotes>>[number]> };
+
+const groupedNotes = page.data.reduce(
+	(acc, note) => {
+		const date = new Date(note.data.publishDate);
+		const year = String(date.getFullYear());
+		const month = String(date.getMonth() + 1).padStart(2, "0");
+		const key = `${year}-${month}`;
+		if (!acc[key]) acc[key] = [];
+		acc[key].push(note);
+		return acc;
+	},
+	{} as Record<string, typeof page.data>,
+);
+
+const groupedKeys = Object.keys(groupedNotes).sort((a, b) => (a > b ? -1 : 1));
 ---
 
 <PageLayout meta={{ description: "status.cafe + notes stream", title: "Memos" }}>
@@ -29,16 +44,25 @@ const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNot
 
 		<section aria-labelledby="note-waterfall-title" class="memos-panel-section">
 			<h2 class="memos-panel-title" id="note-waterfall-title">NOTE WATERFALL</h2>
-			<div class="memos-note-waterfall" role="feed">
-				{page.data.map((note) => (
-					<article class="memos-note-waterfall-item"><Note note={note} as="h2" isPreview /></article>
-				))}
-			</div>
+			{
+				groupedKeys.map((groupKey) => (
+					<section class="memos-group-section">
+						<h3 class="memos-group-heading">{groupKey}</h3>
+						<div class="memos-note-waterfall" role="feed">
+							{(groupedNotes[groupKey] ?? []).map((note, idx) => (
+								<article class:list={["memos-note-waterfall-item", idx % 2 === 1 && "is-offset"]}>
+									<Note note={note} as="h2" isPreview />
+								</article>
+							))}
+						</div>
+					</section>
+				))
+			}
 		</section>
 
 		<Pagination
-			{...(page.url.prev && { prevUrl: { text: "← Previous Page", url: page.url.prev } })}
-			{...(page.url.next && { nextUrl: { text: "Next Page →", url: page.url.next } })}
+			{...page.url.prev && { prevUrl: { text: "← Previous Page", url: page.url.prev } }}
+			{...page.url.next && { nextUrl: { text: "Next Page →", url: page.url.next } }}
 		/>
 
 		<section class="memos-panel-section">
@@ -54,15 +78,21 @@ const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNot
 		const doc = new DOMParser().parseFromString(text, "text/html");
 		return doc.documentElement.textContent ?? "";
 	};
-	const parseStatusFeed = (xmlText) => [...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)].map((entry) => {
-		const body = entry[1] ?? "";
-		const id = body.match(/<id>([\s\S]*?)<\/id>/i)?.[1]?.trim() ?? "";
-		const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? "";
-		const contentRaw = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "";
-		const content = decodeHtmlText(contentRaw).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
-		if (!id || !content || Number.isNaN(new Date(updated).valueOf())) return null;
-		return { id, content, updated };
-	}).filter(Boolean);
+	const parseStatusFeed = (xmlText) =>
+		[...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)]
+			.map((entry) => {
+				const body = entry[1] ?? "";
+				const id = body.match(/<id>([\s\S]*?)<\/id>/i)?.[1]?.trim() ?? "";
+				const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? "";
+				const contentRaw = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "";
+				const content = decodeHtmlText(contentRaw)
+					.replace(/<[^>]*>/g, " ")
+					.replace(/\s+/g, " ")
+					.trim();
+				if (!id || !content || Number.isNaN(new Date(updated).valueOf())) return null;
+				return { id, content, updated };
+			})
+			.filter(Boolean);
 
 	const fetchStatusFeedText = async () => {
 		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`;
@@ -78,7 +108,12 @@ const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNot
 		if (!statusFeedContainer) return;
 		try {
 			const items = parseStatusFeed(await fetchStatusFeedText());
-			statusFeedContainer.innerHTML = items.map((item) => `<article class="status-card memos-status-stream-item"><time class="block text-xs opacity-70">${new Date(item.updated).toLocaleString("zh-CN")}</time><p class="mt-2 whitespace-pre-wrap text-sm">${item.content}</p></article>`).join("");
+			statusFeedContainer.innerHTML = items
+				.map(
+					(item) =>
+						`<article class="status-card memos-status-stream-item"><time class="block text-xs opacity-70">${new Date(item.updated).toLocaleString("zh-CN")}</time><p class="mt-2 whitespace-pre-wrap text-sm">${item.content}</p></article>`,
+				)
+				.join("");
 		} catch {
 			statusFeedContainer.innerHTML = `<p class="status-card">Unable to load status.cafe stream right now.</p>`;
 		}
@@ -97,6 +132,7 @@ const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNot
 	.memos-page-layout {
 		display: grid;
 		gap: 1rem;
+		letter-spacing: 0.05em;
 	}
 
 	.memos-page-header,
@@ -111,29 +147,46 @@ const { page } = Astro.props as { page: Page<Awaited<ReturnType<typeof getAllNot
 		letter-spacing: 0.12em;
 	}
 
+	.memos-group-heading {
+		font-size: 1.6rem;
+		line-height: 1.2;
+		font-weight: 700;
+		margin: 0.25rem 0 0.75rem;
+	}
+
 	.memos-status-stream-grid {
 		display: grid;
-		gap: 1rem;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.8rem;
 	}
 
 	.memos-note-waterfall {
-		column-count: 2;
-		column-gap: 0.8rem;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.8rem;
 	}
 
 	.memos-note-waterfall-item {
-		break-inside: avoid;
-		margin-bottom: 0.8rem;
-		border: 2px solid #7e8faa;
+		align-self: start;
 	}
 
-	.memos-status-stream-item {
-		border: 2px solid #7e8faa;
+	.memos-note-waterfall-item.is-offset {
+		margin-top: 1rem;
 	}
 
-	@media (max-width: 640px) {
-		.memos-note-waterfall {
-			column-count: 1;
+	.memos-status-stream-item,
+	.memos-note-waterfall-item :global(.status-card) {
+		border: 1px solid #7e8faa;
+	}
+
+	@media (max-width: 700px) {
+		.memos-note-waterfall,
+		.memos-status-stream-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.memos-note-waterfall-item.is-offset {
+			margin-top: 0;
 		}
 	}
 </style>

--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -3,7 +3,6 @@
 }
 
 .site-content-frame {
-	background: rgba(220, 232, 248, 0.68);
 	padding: 0.5rem;
 }
 
@@ -99,14 +98,13 @@
 
 @media (min-width: 1024px) {
 	.home-main-grid {
-		grid-template-columns: 0.72fr 1.25fr;
+		grid-template-columns: 0.65fr 1.4fr 0.65fr;
 	}
 }
 
 .home-sidebar-frame {
 	border: 1px solid #4a78d0;
 	padding: 0.6rem;
-	background: rgba(215, 230, 250, 0.55);
 }
 
 .home-layout-column {
@@ -115,20 +113,57 @@
 	gap: 0.55rem;
 }
 
+.home-middle-column {
+	display: grid;
+	gap: 0.8rem;
+}
+
+.home-image-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.7rem;
+}
+
+.home-image-placeholder {
+	min-height: 150px;
+	border: 1px dashed #4a78d0;
+	background: rgba(239, 247, 255, 0.7);
+	display: grid;
+	place-items: center;
+	font-size: 0.74rem;
+	letter-spacing: 0.06em;
+	text-align: center;
+	padding: 0.6rem;
+}
+
+.home-image-placeholder--wide {
+	grid-column: span 2;
+	min-height: 180px;
+}
+
+.home-right-rail .home-right-card + .home-right-card {
+	border-top: 1px dashed #7e8faa;
+	padding-top: 0.6rem;
+}
+
+.home-right-card h2 {
+	font-size: 0.74rem;
+	letter-spacing: 0.08em;
+	font-weight: 700;
+	margin-bottom: 0.35rem;
+}
+
+.home-right-card img {
+	width: 100%;
+	cursor: pointer;
+	border: 1px solid #7e8faa;
+}
+
 .angel-divider {
 	text-align: center;
 	font-size: 0.78rem;
 	color: #46608f;
 	line-height: 1;
-}
-
-.home-column-filler {
-	border: 1px dashed #7e8faa;
-	background: rgba(235, 243, 255, 0.9);
-	color: #4a5b76;
-	font-size: 0.78rem;
-	text-align: center;
-	padding: 0.45rem;
 }
 
 .readme-cover-wrap {
@@ -143,24 +178,6 @@
 	position: absolute;
 	right: 0.5rem;
 	bottom: 0.5rem;
-	border: 1px solid #7e8faa;
-}
-
-.status-split {
-	display: grid;
-	grid-template-columns: 1.7fr 1fr;
-	gap: 0.75rem;
-	padding: 0.7rem;
-}
-
-.status-split > div:first-child {
-	border-right: 1px dashed #7e8faa;
-	padding-right: 0.75rem;
-}
-
-.status-side-image-wrap img {
-	width: 100%;
-	cursor: pointer;
 	border: 1px solid #7e8faa;
 }
 
@@ -189,48 +206,10 @@
 	object-fit: contain;
 }
 
-.site-nav-shell {
-	border: 1px solid #4a78d0;
-	background: #d5e8fa;
-	padding: 0.45rem;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
-	align-items: center;
-	gap: 0.35rem;
-}
-
-.site-nav-item {
-	position: relative;
-}
-
-.site-nav-link,
-.site-nav-button {
-	border: 1px solid #7e8faa;
-	background: #edf4ff;
-	padding: 0.22rem 0.55rem;
-	font-size: 0.76rem;
-	line-height: 1.15;
-}
-
-.site-nav-submenu {
-	position: absolute;
-	left: 50%;
-	top: 100%;
-	z-index: 10;
-	margin-top: 0.3rem;
-	min-width: 11rem;
-	transform: translateX(-50%);
-	border: 1px solid #7e8faa;
-	padding: 0.35rem;
-	display: grid;
-	gap: 0.25rem;
-}
-
 .site-action-rail {
 	position: fixed;
 	top: 1rem;
-	right: max(0.75rem, calc((100vw - 84rem) / 2 + 0.75rem));
+	right: max(0.75rem, calc((100vw - 88rem) / 2 + 0.75rem));
 	z-index: 80;
 	display: grid;
 	gap: 0.35rem;
@@ -240,6 +219,27 @@
 	border: 1px solid #7e8faa;
 	background: rgba(220, 232, 248, 0.9);
 	padding: 0.22rem;
+}
+
+.inner-page-shell {
+	display: grid;
+	gap: 0.85rem;
+}
+
+.inner-page-content {
+	padding: 0.85rem 1rem;
+	border: 1px solid #4a78d0;
+	background: rgba(238, 246, 255, 0.58);
+}
+
+@media (min-width: 1024px) {
+	.inner-page-shell {
+		grid-template-columns: 0.65fr 2.05fr;
+	}
+}
+
+.shared-left-sidebar[data-compact="1"] .title {
+	font-size: 1.15rem;
 }
 
 .click-kaomoji-effect {
@@ -264,5 +264,15 @@
 	100% {
 		opacity: 0;
 		transform: translate(-50%, -160%) scale(1.25);
+	}
+}
+
+@media (max-width: 640px) {
+	.home-image-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.home-image-placeholder--wide {
+		grid-column: span 1;
 	}
 }

--- a/src/styles/pages/posts.css
+++ b/src/styles/pages/posts.css
@@ -1,3 +1,7 @@
+.posts-page {
+	letter-spacing: 0.05em;
+}
+
 .posts-page .card-chip {
 	font-size: 0.74rem;
 	padding: 0.15rem 0.45rem;
@@ -7,16 +11,21 @@
 	margin-bottom: 2.2rem;
 }
 
+.posts-page h2.title {
+	font-size: 1.7rem;
+	line-height: 1.2;
+}
+
 .posts-page ul {
 	margin-top: 0.55rem;
 }
 
 .posts-page li[data-tags] {
 	margin-top: 0.2rem;
-	font-size: 0.86rem;
-	line-height: 1.35;
+	font-size: 0.92rem;
+	line-height: 1.5;
 }
 
 .posts-page .post-preview-date {
-	font-size: 0.75rem;
+	font-size: 0.82rem;
 }


### PR DESCRIPTION
### Motivation
- Unify inner-page layout so most pages reuse a left sidebar and present content in a merged center/right area for consistent UX.
- Rework the homepage to a three-column layout with room for multiple images and a compact left/right rail to match the visual reference and spacing requirements.
- Improve memos/posts presentation by adding month-year separators, a two-column staggered waterfall for memos, and clearer typography for posts.

### Description
- Add a reusable `SharedLeftSidebar` component at `src/components/layout/SharedLeftSidebar.astro` and wire it into `Base.astro` so non-home, non-about pages render a two-column inner shell with the shared sidebar. 
- Replace top navigation rendering and increase the site content max width from `max-w-5xl` to `max-w-6xl` in `src/layouts/Base.astro`. 
- Redesign homepage at `src/pages/index.astro` into a three-column grid using the shared left sidebar, a wider center column with multiple image placeholders, and a right rail containing five cards separated by dashed lines and 1px solid outer borders. 
- Implement rotating random English quotes (blue palette) in the marquee via client script in `Base.astro`. 
- Update memos listing at `src/pages/memos/[...page].astro` to group notes by `YYYY-MM`, render groups with headings, and present notes in a two-column staggered waterfall where preview cards align with `status-card` styling. 
- Tweak styles: overhaul `src/styles/components/homepage.css` to support the new layout and side rails, and update `src/styles/pages/posts.css` to increase letter-spacing, enlarge year headings, and slightly increase date sizing.

### Testing
- Ran `npm run build` and the static site built successfully (18 pages built); result: succeeded. 
- Ran the dev server and captured screenshots of `http://localhost:4321/`, `/posts/`, and `/memos/` to validate visual changes; screenshots were produced and saved as artifacts. 
- Ran `npm run check` (Astro diagnostics for the modified files reported no blocking errors), but repository-wide lint/biome diagnostics include unrelated issues and caused a non-zero check status; result: warnings/infos from the wider codebase (not blocking for these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed7638004832c9c96fa68f72fb2d2)