### PR TITLE
Redesign site with pastel hospital-inspired UI, responsive pages, and new archive/memos flows

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,45 +1,7 @@
 ---
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
-
-const startDateISO = "2025-07-30T00:00:00+08:00";
-
-const countContentCharacters = (dir: string): number => {
-	let total = 0;
-	for (const entry of readdirSync(dir)) {
-		const target = join(dir, entry);
-		const stat = statSync(target);
-		if (stat.isDirectory()) {
-			total += countContentCharacters(target);
-			continue;
-		}
-		if (!/\.(md|mdx)$/i.test(entry)) continue;
-		const text = readFileSync(target, "utf-8");
-		total += text.replace(/\s+/g, "").length;
-	}
-	return total;
-};
-
-const contentChars = countContentCharacters("src/content");
+const currentYear = new Date().getFullYear();
 ---
 
-<footer
-	class="mt-auto flex w-full flex-col items-center justify-center gap-y-2 pt-20 pb-4 text-center align-top text-gray-600 sm:flex-row sm:justify-between sm:text-xs dark:text-gray-400"
->
-	<div class="me-0 sm:me-4">&copy; Eucaly 2026.</div>
-	<div id="site-runtime" data-start-date={startDateISO} data-total-words={contentChars}>此网站运行了计算中...</div>
+<footer class="site-footer">
+	<p>© {currentYear} Eucaly. Built with love and Astro.</p>
 </footer>
-
-<script is:inline>
-	const runtimeEl = document.getElementById("site-runtime");
-	if (runtimeEl) {
-		const startDate = new Date(runtimeEl.dataset.startDate || "2025-07-30T00:00:00+08:00");
-		const totalWords = Number(runtimeEl.dataset.totalWords || "0");
-		const now = new Date();
-		const days = Math.max(
-			1,
-			Math.floor((now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1,
-		);
-		runtimeEl.textContent = `此网站运行了 ${days} 天，共嘟嘟了 ${totalWords} 字`;
-	}
-</script>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,48 +1,26 @@
 ---
 import { menuLinks } from "@/site.config";
+
+const navItems = menuLinks.flatMap((link) =>
+	link.children?.length ? link.children : [link],
+).filter((item) => item.path);
 ---
 
-<header class="mb-6" id="main-header">
-	<nav aria-label="Main menu" class="site-nav-shell" id="navigation-menu">
-		{menuLinks.map((link, index) =>
-			link.children?.length ? (
-				<div class="site-nav-item site-nav-item--submenu">
-					<button aria-expanded="false" class="site-nav-button" data-submenu-toggle={index} type="button">
-						{link.title} ▾
-					</button>
-					<div class="submenu glass-panel site-nav-submenu hidden">
-						{link.children.map((item) => (
-							<a class="site-nav-link" href={item.path}>{item.title}</a>
-						))}
-					</div>
-				</div>
-			) : (
+<header id="main-header">
+	<nav aria-label="Main menu" class="site-nav-shell">
+		<a class="site-logo" href="/">Eucaly</a>
+		<div class="site-nav-links">
+			{navItems.map((link) => (
 				<a
 					aria-current={Astro.url.pathname === link.path ? "page" : false}
-					class="site-nav-link site-nav-item"
+					class="site-nav-link"
 					href={link.path}
 					target={link.external ? "_blank" : undefined}
 					rel={link.external ? "noreferrer" : undefined}
 				>
 					{link.title}
 				</a>
-			),
-		)}
+			))}
+		</div>
 	</nav>
 </header>
-
-<script>
-	const initSubmenus = () => {
-		document.querySelectorAll("[data-submenu-toggle]").forEach((btn) => {
-			if (!(btn instanceof HTMLElement)) return;
-			if (btn.dataset.bound === "1") return;
-			btn.dataset.bound = "1";
-			btn.addEventListener("click", () => {
-				const submenu = btn.parentElement?.querySelector(".submenu");
-				submenu?.classList.toggle("hidden");
-			});
-		});
-	};
-	document.addEventListener("astro:page-load", initSubmenus);
-	initSubmenus();
-</script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,89 +1,43 @@
 ---
 import BaseHead from "@/components/BaseHead.astro";
 import Footer from "@/components/layout/Footer.astro";
-import SharedLeftSidebar from "@/components/layout/SharedLeftSidebar.astro";
-import Search from "@/components/Search.astro";
-import SkipLink from "@/components/SkipLink.astro";
-import ThemeProvider from "@/components/ThemeProvider.astro";
-import ThemeToggle from "@/components/ThemeToggle.astro";
+import Header from "@/components/layout/Header.astro";
 import { siteConfig } from "@/site.config";
 import type { SiteMeta } from "@/types";
 
 interface Props { meta: SiteMeta; }
 
 const { meta: { articleDate, description = siteConfig.description, ogImage, title } } = Astro.props;
-const isHome = Astro.url.pathname === "/";
-const isAbout = Astro.url.pathname === "/about/";
-const useSharedLeftSidebar = !isHome && !isAbout;
-const topBannerImage = "https://i.postimg.cc/43GZ382v/e2511.png";
-const pageBackground = "https://i.postimg.cc/Y2bwBpkP/26898018.jpg";
 ---
 
 <html lang={siteConfig.lang}>
 	<head><BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} /></head>
-	<body class="site-shell" style={`background-image: linear-gradient(var(--color-bg-overlay), var(--color-bg-overlay)), url(${pageBackground});`}>
-		<ThemeProvider />
-		<SkipLink />
-		<div class="site-action-rail" role="group" aria-label="Search and theme controls"><Search /><ThemeToggle /></div>
-		<div>
-			<div class="site-hero-strip"><a aria-current={Astro.url.pathname === "/" ? "page" : false} class="home-top-image-link" href="/"><img alt="top banner" class="home-top-image" src={topBannerImage} /></a></div>
-			<main id="main">
-				{useSharedLeftSidebar ? <section class="inner-page-shell"><SharedLeftSidebar compact /><div class="inner-page-content"><slot /></div></section> : <slot />}
-			</main>
+	<body class="site-shell">
+		<div aria-hidden="true" class="initial-loader" id="initial-loader">
+			<div class="initial-loader__icon">🪽</div>
 		</div>
+		<Header />
+		<main class="page-fade" id="main"><slot /></main>
 		<Footer />
-		<div aria-hidden="true" id="global-lightbox"><img alt="Enlarged image" id="global-lightbox-image" src="" /></div>
 	</body>
 </html>
 
 <script is:inline>
-	const clickFaces = ["❄(◕‿◕)❄", "(ﾉ*･ω･)ﾉ❄", "✧(｡•̀ᴗ-)", "(๑˃ᴗ˂)ﻭ", "˗ˏˋ ❄ ˎˊ˗"]; // 定义点击特效文本。
-	const showClickKaomoji = (event) => { // 定义点击冒泡特效方法。
-		const target = event.target; // 获取事件源。
-		if (!(target instanceof Element)) return; // 过滤非元素节点。
-		if (target.closest("a, button, input, textarea")) return; // 避免影响可交互元素。
-		const effect = document.createElement("span"); // 创建特效节点。
-		effect.className = "click-kaomoji-effect"; // 设置特效样式类名。
-		effect.textContent = clickFaces[Math.floor(Math.random() * clickFaces.length)]; // 随机设置文本。
-		effect.style.left = `${event.clientX}px`; // 设置横坐标。
-		effect.style.top = `${event.clientY}px`; // 设置纵坐标。
-		document.body.append(effect); // 插入特效节点。
-		setTimeout(() => effect.remove(), 900); // 延时移除特效。
-	};
-	const bindGlobalLightbox = () => { // 定义全局图片灯箱绑定。
-		const lightbox = document.getElementById("global-lightbox"); // 获取灯箱容器。
-		const lightboxImage = document.getElementById("global-lightbox-image"); // 获取灯箱图片。
-		if (!lightbox || !(lightboxImage instanceof HTMLImageElement)) return; // 节点不存在则退出。
-		document.querySelectorAll("article img, .prose img, .gallery-image").forEach((img) => { // 遍历可放大图片。
-			if (!(img instanceof HTMLImageElement) || !img.src) return; // 过滤无效图片。
-			img.style.cursor = "zoom-in"; // 设置鼠标样式。
-			if (img.dataset.lightboxBound === "1") return; // 已绑定则跳过。
-			img.dataset.lightboxBound = "1"; // 标记已绑定。
-			img.addEventListener("click", () => { // 点击时显示灯箱。
-				lightboxImage.src = img.currentSrc || img.src; // 同步图片地址。
-				lightboxImage.alt = img.alt || "Image"; // 同步图片文案。
-				lightbox.dataset.open = "true"; // 打开灯箱。
-				lightbox.setAttribute("aria-hidden", "false"); // 设置可访问状态。
-			});
-		});
-		if (lightbox.dataset.bound !== "1") { // 首次绑定关闭逻辑。
-			lightbox.dataset.bound = "1"; // 标记灯箱已绑定。
-			lightbox.addEventListener("click", () => { // 点击遮罩关闭灯箱。
-				lightbox.dataset.open = "false"; // 关闭灯箱。
-				lightbox.setAttribute("aria-hidden", "true"); // 更新可访问状态。
-			});
-			document.addEventListener("keydown", (event) => { // 监听键盘关闭事件。
-				if (event.key === "Escape") { // 仅处理 Escape 键。
-					lightbox.dataset.open = "false"; // 关闭灯箱。
-					lightbox.setAttribute("aria-hidden", "true"); // 更新可访问状态。
-				}
-			});
+	const initLayoutEffects = () => {
+		const loader = document.getElementById("initial-loader");
+		if (loader && !sessionStorage.getItem("site-loader-seen")) {
+			sessionStorage.setItem("site-loader-seen", "1");
+			setTimeout(() => loader.classList.add("initial-loader--hidden"), 2000);
+		} else {
+			loader?.classList.add("initial-loader--hidden");
 		}
-		if (document.body.dataset.kaomojiBound !== "1") { // 首次绑定点击特效。
-			document.body.dataset.kaomojiBound = "1"; // 标记已绑定。
-			document.addEventListener("pointerdown", showClickKaomoji); // 绑定指针事件。
-		}
+
+		const nav = document.getElementById("main-header");
+		const toggleNav = () => nav?.classList.toggle("is-scrolled", window.scrollY > 8);
+		toggleNav();
+		window.addEventListener("scroll", toggleNav, { passive: true });
 	};
-	document.addEventListener("astro:page-load", bindGlobalLightbox); // Astro 页面切换时绑定。
-	bindGlobalLightbox(); // 首屏立即绑定。
+
+	document.addEventListener("astro:page-load", initLayoutEffects);
+	initLayoutEffects();
 </script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,30 +1,54 @@
 ---
-import { getEntry, render } from "astro:content";
 import { Icon } from "astro-icon/components";
 import PageLayout from "@/layouts/Base.astro";
 
-const meta = { description: "About me", title: "About" };
 const profileCoverImage = "https://i.postimg.cc/4dLTBX4R/e250416.jpg";
 const contacts = [
 	{ icon: "mdi:github", label: "GitHub", url: "https://github.com/isntbunny" },
 	{ icon: "mdi:email-outline", label: "Email", url: "mailto:isntbunny@outlook.com" },
 ];
-
-const aboutEntry = await getEntry("page", "about");
-if (!aboutEntry) throw new Error("Missing src/content/page/about.md");
-const { Content } = await render(aboutEntry);
+const skills = [
+	{ name: "Illustration", value: 78 },
+	{ name: "Writing", value: 70 },
+	{ name: "Frontend", value: 64 },
+	{ name: "Language", value: 82 },
+];
 ---
 
-<PageLayout meta={meta}>
-	<h1 class="title">Readme.md</h1>
-	<section class="about-readme-shell">
-		<div class="prose prose-sm prose-cactus max-w-none"><Content /></div>
-		<div class="about-avatar-wrap"><img alt="profile photo" src={profileCoverImage} /></div>
+<PageLayout meta={{ description: "About me", title: "About" }}>
+	<section class="site-card">
+		<div class="about-grid">
+			<div><img alt="profile photo" class="about-avatar" id="about-avatar" src={profileCoverImage} /></div>
+			<div>
+				<h1 class="about-name">Eucaly</h1>
+				<p class="about-bio">A dreamy student creator who loves light blue palettes, sketching, and coding tiny features that feel soft and calm.</p>
+				<div class="about-social">
+					{contacts.map((item) => <a href={item.url} target="_blank" rel="noreferrer"><Icon name={item.icon} /> {item.label}</a>)}
+				</div>
+			</div>
+		</div>
 	</section>
-	<section>
-		<p>Find me on</p>
-		<ul>
-			{contacts.map((item) => <li><a href={item.url} target="_blank" rel="noreferrer"><Icon name={item.icon} /> <span>{item.label}</span></a></li>)}
-		</ul>
+
+	<section class="site-card skills">
+		<h2>Skills</h2>
+		{skills.map((skill) => (
+			<div class="skill-row">
+				<span>{skill.name}</span>
+				<div class="skill-bar"><span class="skill-fill" data-skill={skill.value}></span></div>
+				<span>{skill.value}%</span>
+			</div>
+		))}
 	</section>
 </PageLayout>
+
+<script is:inline>
+	const initAbout = () => {
+		document.getElementById("about-avatar")?.classList.add("about-avatar-spin");
+		document.querySelectorAll(".skill-fill").forEach((bar, index) => {
+			const target = bar.getAttribute("data-skill") || "0";
+			setTimeout(() => { bar.style.width = `${target}%`; }, 200 + index * 120);
+		});
+	};
+	document.addEventListener("astro:page-load", initAbout);
+	initAbout();
+</script>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,0 +1,48 @@
+---
+import { getCollection } from "astro:content";
+import PageLayout from "@/layouts/Base.astro";
+
+const posts = (await getCollection("post", ({ data }) => !data.draft)).sort(
+	(a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime(),
+);
+
+const grouped = posts.reduce<Record<string, Record<string, typeof posts>>>((acc, post) => {
+	const date = post.data.publishDate;
+	const year = String(date.getFullYear());
+	const month = date.toLocaleString("en-US", { month: "long" });
+	acc[year] ??= {};
+	acc[year][month] ??= [];
+	acc[year][month].push(post);
+	return acc;
+}, {});
+---
+
+<PageLayout meta={{ title: "Archive", description: "Post archive by year and month" }}>
+	<h1>Archive</h1>
+	<div style="display:grid;gap:26px;">
+		{Object.entries(grouped).map(([year, months], yearIndex) => (
+			<section class="fade-stagger" style={`animation-delay:${yearIndex * 0.1}s`}>
+				<h2 style="font-size:32px;color:#c7e9f0;">{year}</h2>
+				<hr style="border:none;border-top:1px dashed #e2e8f0;margin:8px 0 14px;" />
+				<div style="display:grid;gap:14px;">
+					{Object.entries(months).map(([month, list], monthIndex) => (
+						<section class="fade-stagger" style={`animation-delay:${monthIndex * 0.05}s`}>
+							<span style="display:inline-block;background:rgba(199,233,240,.2);border-radius:999px;padding:4px 12px;">{month}</span>
+							<ul style="margin:10px 0 0 24px;padding-left:14px;border-left:2px solid #c7e9f0;display:grid;gap:8px;">
+								{list.map((post) => (
+									<li style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+										<a href={`/posts/${post.id}/`} style="font-size:16px;">{post.data.title}</a>
+										<div style="display:flex;align-items:center;gap:8px;">
+											<time class="small-muted" style="font-size:12px;">{post.data.publishDate.toLocaleDateString("en-US")}</time>
+											{post.data.tags?.[0] && <span class="site-chip">{post.data.tags[0]}</span>}
+										</div>
+									</li>
+								))}
+							</ul>
+						</section>
+					))}
+				</div>
+			</section>
+		))}
+	</div>
+</PageLayout>

--- a/src/pages/bangumi/index.astro
+++ b/src/pages/bangumi/index.astro
@@ -3,20 +3,12 @@ import PageLayout from "@/layouts/Base.astro";
 import { siteConfig } from "@/site.config";
 
 const username = siteConfig.bangumiUsername;
-const statusMap: Record<number, string> = {
-	1: "想看",
-	2: "看过",
-	3: "在看",
-	4: "搁置",
-	5: "抛弃",
-};
+const statusMap: Record<number, string> = { 1: "Wish", 2: "Completed", 3: "Watching", 4: "On hold", 5: "Dropped" };
 
 async function fetchCollection(subjectType: number) {
 	try {
-		const endpoint = `https://api.bgm.tv/v0/users/${username}/collections?subject_type=${subjectType}&limit=24`;
-		const res = await fetch(endpoint, {
-			headers: { "user-agent": "isntbunny-blog/1.0" },
-		});
+		const endpoint = `https://api.bgm.tv/v0/users/${username}/collections?subject_type=${subjectType}&limit=30`;
+		const res = await fetch(endpoint, { headers: { "user-agent": "isntbunny-blog/1.0" } });
 		if (!res.ok) return [];
 		const data = await res.json();
 		return data?.data ?? [];
@@ -28,142 +20,65 @@ async function fetchCollection(subjectType: number) {
 const [animeItems, mangaItems] = await Promise.all([fetchCollection(2), fetchCollection(1)]);
 ---
 
-<PageLayout meta={{ title: "番组计划", description: "Bangumi 动画与漫画列表" }}>
-	<h1 class="title mb-6">番组计划</h1>
-	<p class="mb-6 text-xs opacity-80">当前用户：<code>{username}</code></p>
-
-	<div class="mb-6 flex gap-2">
-		<button class="glass-panel card-chip" data-tab="anime" type="button">
-			动画
-		</button>
-		<button class="glass-panel card-chip" data-tab="manga" type="button">漫画</button>
+<PageLayout meta={{ title: "Bangumi", description: "Bangumi progress" }}>
+	<h1>Bangumi</h1>
+	<div class="bangumi-tabs">
+		<button class="bangumi-tab is-active" data-tab="anime" type="button">Anime</button>
+		<button class="bangumi-tab" data-tab="manga" type="button">Manga</button>
 	</div>
 
 	<section data-tab-panel="anime">
-		{animeItems.length ? (
-			<div class="grid gap-4" id="anime-grid">
-				{animeItems.map((entry: any) => {
-					const subject = entry?.subject;
-					const title = subject?.name_cn || subject?.name || "未命名条目";
-					const image = subject?.images?.common || subject?.images?.medium || "";
-					const score = entry?.rate ? `我的评分：${entry.rate}` : "未评分";
-					const status = statusMap[entry?.type] || "未分类";
-					const url = subject?.id ? `https://bgm.tv/subject/${subject.id}` : "https://bgm.tv";
-					return (
-						<article class="status-card">
-							<a href={url} target="_blank" rel="noreferrer" class="grid grid-cols-[70px_1fr] gap-3">
-								{image ? (
-									<img src={image} alt={title} class="h-24 w-[70px] rounded object-cover" loading="lazy" />
-								) : (
-									<div class="h-24 w-[70px] rounded bg-zinc-200/60 dark:bg-zinc-800/70"></div>
-								)}
-								<div>
-									<h3 class="font-semibold">{title}</h3>
-									<p class="mt-2 text-xs opacity-80">状态：{status}</p>
-									<p class="text-xs opacity-80">{score}</p>
-								</div>
-							</a>
-						</article>
-					);
-				})}
-			</div>
-		) : (
-			<p>还没有获取到动画数据捏</p>
-		)}
+		<div class="bangumi-grid">
+			{animeItems.map((entry: any, index: number) => {
+				const subject = entry?.subject;
+				const title = subject?.name_cn || subject?.name || "Untitled";
+				const image = subject?.images?.common || subject?.images?.medium || "https://images.unsplash.com/photo-1516116216624-53e697fedbea?auto=format&fit=crop&w=600&q=80";
+				const score = entry?.rate ? `Score ${entry.rate}` : "No score";
+				const status = statusMap[entry?.type] || "Unknown";
+				return (
+					<article class="site-card bangumi-item fade-stagger" style={`animation-delay:${index * 0.04}s`}>
+						<img src={image} alt={title} loading="lazy" />
+						<h3 title={title}>{title}</h3>
+						<p class="small-muted">{status} · {score}</p>
+					</article>
+				);
+			})}
+		</div>
 	</section>
 
-	<section class="hidden" data-tab-panel="manga">
-		{mangaItems.length ? (
-			<div class="grid gap-4" id="manga-grid">
-				{mangaItems.map((entry: any) => {
-					const subject = entry?.subject;
-					const title = subject?.name_cn || subject?.name || "未命名条目";
-					const image = subject?.images?.common || subject?.images?.medium || "";
-					const score = entry?.rate ? `我的评分：${entry.rate}` : "未评分";
-					const status = statusMap[entry?.type] || "未分类";
-					const url = subject?.id ? `https://bgm.tv/subject/${subject.id}` : "https://bgm.tv";
-					return (
-						<article class="status-card">
-							<a href={url} target="_blank" rel="noreferrer" class="grid grid-cols-[70px_1fr] gap-3">
-								{image ? (
-									<img src={image} alt={title} class="h-24 w-[70px] rounded object-cover" loading="lazy" />
-								) : (
-									<div class="h-24 w-[70px] rounded bg-zinc-200/60 dark:bg-zinc-800/70"></div>
-								)}
-								<div>
-									<h3 class="font-semibold">{title}</h3>
-									<p class="mt-2 text-xs opacity-80">状态：{status}</p>
-									<p class="text-xs opacity-80">{score}</p>
-								</div>
-							</a>
-						</article>
-					);
-				})}
-			</div>
-		) : (
-			<p>还没有获取到漫画数据。</p>
-		)}
+	<section data-tab-panel="manga" hidden>
+		<div class="bangumi-grid">
+			{mangaItems.map((entry: any, index: number) => {
+				const subject = entry?.subject;
+				const title = subject?.name_cn || subject?.name || "Untitled";
+				const image = subject?.images?.common || subject?.images?.medium || "https://images.unsplash.com/photo-1516116216624-53e697fedbea?auto=format&fit=crop&w=600&q=80";
+				const score = entry?.rate ? `Score ${entry.rate}` : "No score";
+				const status = statusMap[entry?.type] || "Unknown";
+				return (
+					<article class="site-card bangumi-item fade-stagger" style={`animation-delay:${index * 0.04}s`}>
+						<img src={image} alt={title} loading="lazy" />
+						<h3 title={title}>{title}</h3>
+						<p class="small-muted">{status} · {score}</p>
+					</article>
+				);
+			})}
+		</div>
 	</section>
 </PageLayout>
 
-<script define:vars={{ username }} is:inline>
+<script is:inline>
 	const initBangumiTabs = () => {
-		const tabButtons = document.querySelectorAll("[data-tab]");
-		const tabPanels = document.querySelectorAll("[data-tab-panel]");
-		if (!tabButtons.length) return;
-		const activateTab = (tab) => {
-			tabButtons.forEach((btn) => {
-				const isActive = btn.getAttribute("data-tab") === tab;
-				btn.classList.toggle("font-semibold", isActive);
+		const tabs = [...document.querySelectorAll(".bangumi-tab")];
+		const panels = [...document.querySelectorAll("[data-tab-panel]")];
+		tabs.forEach((tab) => {
+			if (tab.dataset.bound === "1") return;
+			tab.dataset.bound = "1";
+			tab.addEventListener("click", () => {
+				const target = tab.getAttribute("data-tab");
+				tabs.forEach((item) => item.classList.toggle("is-active", item === tab));
+				panels.forEach((panel) => panel.toggleAttribute("hidden", panel.getAttribute("data-tab-panel") !== target));
 			});
-			tabPanels.forEach((panel) => {
-				panel.classList.toggle("hidden", panel.getAttribute("data-tab-panel") !== tab);
-			});
-		};
-		tabButtons.forEach((btn) => {
-			if (btn.dataset.bound === "1") return;
-			btn.dataset.bound = "1";
-			btn.addEventListener("click", () => activateTab(btn.getAttribute("data-tab")));
 		});
-		const loadClientFallback = async () => {
-			const animeGrid = document.getElementById("anime-grid");
-			const mangaGrid = document.getElementById("manga-grid");
-			const needAnime = animeGrid && animeGrid.children.length === 0;
-			const needManga = mangaGrid && mangaGrid.children.length === 0;
-			if (!needAnime && !needManga) return;
-
-			const fetchCollection = async (subjectType) => {
-				const endpoint = `https://api.bgm.tv/v0/users/${encodeURIComponent(username)}/collections?subject_type=${subjectType}&limit=24`;
-				const res = await fetch(endpoint);
-				if (!res.ok) return [];
-				const data = await res.json();
-				return data?.data ?? [];
-			};
-
-			const render = (root, items) => {
-				if (!root || !items.length) return;
-				root.innerHTML = items
-					.map((entry) => {
-						const subject = entry?.subject || {};
-						const title = subject?.name_cn || subject?.name || "未命名条目";
-						const image = subject?.images?.common || subject?.images?.medium || "";
-						const score = entry?.rate ? `我的评分：${entry.rate}` : "未评分";
-						const status = ({1:"想看",2:"看过",3:"在看",4:"搁置",5:"抛弃"})[entry?.type] || "未分类";
-						const url = subject?.id ? `https://bgm.tv/subject/${subject.id}` : "https://bgm.tv";
-						return `<article class="status-card"><a href="${url}" target="_blank" rel="noreferrer" class="grid grid-cols-[70px_1fr] gap-3">${image ? `<img src="${image}" alt="${title}" class="h-24 w-[70px] rounded object-cover" loading="lazy" />` : `<div class="h-24 w-[70px] rounded bg-zinc-200/60 dark:bg-zinc-800/70"></div>`}<div><h3 class="font-semibold">${title}</h3><p class="mt-2 text-xs opacity-80">状态：${status}</p><p class="text-xs opacity-80">${score}</p></div></a></article>`;
-					})
-					.join("");
-			};
-
-			try {
-				const [anime, manga] = await Promise.all([fetchCollection(2), fetchCollection(1)]);
-				if (needAnime) render(animeGrid, anime);
-				if (needManga) render(mangaGrid, manga);
-			} catch {}
-		};
-
-		loadClientFallback();
-
 	};
 	document.addEventListener("astro:page-load", initBangumiTabs);
 	initBangumiTabs();

--- a/src/pages/gallery/[section].astro
+++ b/src/pages/gallery/[section].astro
@@ -6,36 +6,69 @@ import PageLayout from "@/layouts/Base.astro";
 export const getStaticPaths = (async () => {
 	const [gallery] = await getCollection("gallery");
 	if (!gallery) return [];
-	return gallery.data.sections.map((section) => ({
-		params: { section: section.slug },
-		props: { sectionData: section },
-	}));
+	return gallery.data.sections.map((section) => ({ params: { section: section.slug }, props: { sectionData: section } }));
 }) satisfies GetStaticPaths;
 
 const { sectionData } = Astro.props;
+const allItems = sectionData.months.flatMap((group) => group.items.map((item) => ({ ...item, month: group.month })));
 ---
 
 <PageLayout meta={{ title: sectionData.title, description: sectionData.description ?? "Gallery section" }}>
-	<a class="textlink text-sm" href="/gallery/">← Back to Gallery</a>
-	<h1 class="title mb-2 mt-3">{sectionData.title}</h1>
-	{sectionData.description && <p class="mb-6 text-sm opacity-80">{sectionData.description}</p>}
-
-	<div class="space-y-8">
-		{sectionData.months.map((group) => (
-			<section>
-				<h2 class="mb-4 text-lg font-semibold">{group.month}</h2>
-				<div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-					{group.items.map((item) => (
-						<article class="glass-panel overflow-hidden rounded-xl">
-							<img src={item.image} alt={item.title} class="gallery-image h-56 w-full object-cover" loading="lazy" />
-							<div class="p-4">
-								<h3 class="font-semibold">{item.title}</h3>
-								{item.description && <p class="mt-2 text-sm opacity-80">{item.description}</p>}
-							</div>
-						</article>
-					))}
-				</div>
-			</section>
+	<a href="/gallery/">← Back</a>
+	<h1>{sectionData.title}</h1>
+	<div class="gallery-grid">
+		{allItems.map((item, index) => (
+			<article class="site-card gallery-tile" data-index={index} data-src={item.image} data-title={item.title} data-desc={item.description ?? item.month}>
+				<div class="gallery-skeleton"></div>
+				<img src={item.image} alt={item.title} class="gallery-image" loading="lazy" />
+				<h3>{item.title}</h3>
+				<p class="small-muted">{item.description ?? item.month}</p>
+			</article>
 		))}
 	</div>
+
+	<div class="gallery-lightbox" id="gallery-lightbox" hidden>
+		<button class="gallery-arrow" data-dir="prev" type="button">←</button>
+		<div>
+			<img id="gallery-lightbox-image" src="" alt="" />
+			<p id="gallery-lightbox-text"></p>
+		</div>
+		<button class="gallery-arrow" data-dir="next" type="button">→</button>
+	</div>
 </PageLayout>
+
+<script is:inline>
+	const initGallery = () => {
+		const tiles = [...document.querySelectorAll(".gallery-tile")];
+		tiles.forEach((tile) => {
+			const img = tile.querySelector("img");
+			const skeleton = tile.querySelector(".gallery-skeleton");
+			if (!img || !skeleton) return;
+			if (img.complete) skeleton.setAttribute("hidden", "hidden");
+			img.addEventListener("load", () => skeleton.setAttribute("hidden", "hidden"), { once: true });
+		});
+
+		const box = document.getElementById("gallery-lightbox");
+		const lightboxImage = document.getElementById("gallery-lightbox-image");
+		const text = document.getElementById("gallery-lightbox-text");
+		let current = 0;
+		const open = (index) => {
+			const item = tiles[index];
+			if (!item || !box || !lightboxImage || !text) return;
+			current = index;
+			lightboxImage.src = item.dataset.src || "";
+			lightboxImage.alt = item.dataset.title || "";
+			text.textContent = `${item.dataset.title || ""} — ${item.dataset.desc || ""}`;
+			box.removeAttribute("hidden");
+		};
+		tiles.forEach((tile, index) => tile.addEventListener("click", () => open(index)));
+		box?.addEventListener("click", (e) => { if (e.target === box) box.setAttribute("hidden", "hidden"); });
+		document.querySelectorAll(".gallery-arrow").forEach((btn) => btn.addEventListener("click", (e) => {
+			e.stopPropagation();
+			const dir = btn.getAttribute("data-dir");
+			open((current + (dir === "next" ? 1 : -1) + tiles.length) % tiles.length);
+		}));
+	};
+	document.addEventListener("astro:page-load", initGallery);
+	initGallery();
+</script>

--- a/src/pages/gallery/index.astro
+++ b/src/pages/gallery/index.astro
@@ -7,16 +7,13 @@ if (!gallery) throw new Error("Missing src/content/gallery/index.md");
 ---
 
 <PageLayout meta={{ title: "Gallery", description: gallery.data.description ?? "Art gallery" }}>
-	<h1 class="title mb-2">{gallery.data.title}</h1>
-	{gallery.data.description && <p class="mb-6 text-sm opacity-80">{gallery.data.description}</p>}
-	<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+	<h1>Gallery</h1>
+	<div class="gallery-grid sections-grid">
 		{gallery.data.sections.map((section) => (
-			<a class="glass-panel block overflow-hidden rounded-xl" href={`/gallery/${section.slug}/`}>
-				<img src={section.cover} alt={section.title} class="h-44 w-full object-cover" loading="lazy" />
-				<div class="p-4">
-					<h2 class="text-lg font-semibold">{section.title}</h2>
-					{section.description && <p class="mt-2 text-sm opacity-80">{section.description}</p>}
-				</div>
+			<a class="site-card" href={`/gallery/${section.slug}/`}>
+				<img src={section.cover} alt={section.title} class="gallery-image" loading="lazy" />
+				<h2 style="margin-top:10px;">{section.title}</h2>
+				{section.description && <p class="small-muted">{section.description}</p>}
 			</a>
 		))}
 	</div>

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,14 +1,11 @@
 ---
 import PageLayout from "@/layouts/Base.astro";
-
-const meta = {
-	description: "欢迎留言",
-	title: "Guestbook",
-};
-
+import Waline from "@/components/Waline.astro";
 ---
 
-<PageLayout meta={meta}>
-	<h1 class="title mb-6">Guestbook</h1>
-	<iframe src="https://www3.cbox.ws/box/?boxid=3552712&boxtag=FGVbRe" width="100%" height="450" allowtransparency="yes" allow="autoplay" frameborder="0" marginheight="0" marginwidth="0" scrolling="auto"></iframe>	
+<PageLayout meta={{ description: "Leave a message", title: "Guestbook" }}>
+	<h1>Guestbook</h1>
+	<section class="site-card" style="background:rgba(255,255,255,0.6);">
+		<Waline path={Astro.url.pathname} />
+	</section>
 </PageLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,120 +1,143 @@
 ---
-import { execSync } from "node:child_process";
-import SharedLeftSidebar from "@/components/layout/SharedLeftSidebar.astro";
+import { getCollection } from "astro:content";
 import PageLayout from "@/layouts/Base.astro";
 
-const currentYear = new Date().getFullYear();
-const monthEnd = new Date(currentYear, new Date().getMonth() + 1, 0);
-const nextYear = new Date(currentYear + 1, 0, 1);
-const gaokao2027 = new Date("2027-06-07T00:00:00+08:00");
-const daysLeft = (targetDate: Date) =>
-	Math.max(0, Math.ceil((targetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)));
+const posts = await getCollection("post", ({ data }) => !data.draft);
+const latestPost = posts.sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())[0];
 const countdownTargets = [
-	{ key: "monthEnd", label: "Days until month end:", suffix: " days" },
-	{ key: "nextYear", label: "Days until next year:", suffix: " days" },
-	{ key: "gaokao2027", label: "Days until Gaokao 2027:", suffix: " days" },
-] as const;
-const countdownTargetMap = { monthEnd, nextYear, gaokao2027 } as const;
-const countdownItems = countdownTargets.map((item) => ({ ...item, days: daysLeft(countdownTargetMap[item.key]) }));
-const typingText = "幸せのカウントダウン";
-const statusCafeAtomUrl = "https://status.cafe/users/isntbunny.atom";
-const statusImages = ["https://i.postimg.cc/8kxpW5nc/pixel-takopi.png", "https://i.postimg.cc/mZPZtMjV/win-taskfailed.png"];
-const daysSinceLastCommit = (() => {
-	try {
-		const last = Number(execSync("git log -1 --format=%ct", { encoding: "utf-8" }).trim()) * 1000;
-		if (!Number.isFinite(last)) return 0;
-		return Math.max(0, Math.floor((Date.now() - last) / (1000 * 60 * 60 * 24)));
-	} catch {
-		return 0;
-	}
-})();
+	{ label: "Month End", target: new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0) },
+	{ label: "Next Year", target: new Date(new Date().getFullYear() + 1, 0, 1) },
+	{ label: "Gaokao 2027", target: new Date("2027-06-07T00:00:00+08:00") },
+];
+const daysLeft = (target: Date) => Math.max(0, Math.ceil((target.getTime() - Date.now()) / 86400000));
+
+const collections = [
+	{ name: "GitHub", icon: "🐙", url: "https://github.com/isntbunny" },
+	{ name: "Bangumi", icon: "📺", url: "https://bgm.tv/user/isntbunny" },
+	{ name: "Status Cafe", icon: "☕", url: "https://status.cafe/users/isntbunny" },
+];
+
+const apps = ["Notion", "VS Code", "Spotify"];
+const purchase = "A new pastel notebook";
 ---
 
 <PageLayout meta={{ title: "Home" }}>
-	<section class="home-main-grid">
-		<SharedLeftSidebar />
-		<div class="home-middle-column">
-			<section class="win-card">
-				<div class="win-title-bar"><span>README.MD</span></div>
-				<div class="home-image-grid">
-					<script type="text/javascript">boatload_puzzles_format = 'Portrait';</script>
-					<p>Loading <a href="https://www.boatloadpuzzles.com/playcrossword">crossword puzzle</a>. One moment please.</p>
-					<script type="text/javascript" src="//www.boatloadpuzzles.com/Crossword.js"></script>
-				</div>
-			</section>
-		</div>
-		<aside class="home-sidebar-frame home-layout-column home-right-rail">
-			<section class="home-right-card"><h2>Last Update</h2><p>Updated {daysSinceLastCommit} days ago.</p></section>
-			<section class="home-right-card">
-				<h2>Countdown</h2>
+	<section class="home-grid">
+		<article class="site-card fade-stagger" style="animation-delay:0s">
+			<span class="home-card-label">Card 01</span>
+			<h2>今日状态</h2>
+			<div style="display:flex; gap:16px; align-items:center;">
+				<div class="thermometer"></div>
 				<ul>
-					{countdownItems.map((item) => <li>{item.label} <strong>{item.days}{item.suffix}</strong></li>)}
+					<li>Mood Temp: <strong>36.5°C</strong></li>
+					<li>Energy: <strong>82%</strong></li>
+					<li>Inspiration: <strong>74%</strong></li>
 				</ul>
-			</section>
-			<section class="home-right-card"><h2>Status.cafe</h2><time id="home-status-date">Loading...</time><p id="home-status-content">Syncing status.cafe feed ...</p></section>
-			<section class="home-right-card"><h2>Side Image</h2><img alt="status side" id="home-status-side-image" src={statusImages[0]} /></section>
-		</aside>
+			</div>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.1s">
+			<span class="home-card-label">Card 02</span>
+			<h2>我的待办</h2>
+			<div style="font-size:20px;">℞</div>
+			<ul>
+				<li>Finish today’s reading note.</li>
+				<li>Reply to important messages.</li>
+				<li>Update one tiny page detail.</li>
+			</ul>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.2s">
+			<span class="home-card-label">Card 03</span>
+			<h2>倒计时</h2>
+			<ul class="home-countdown-list">
+				{countdownTargets.map((item) => <li><span>{item.label}</span><strong>{daysLeft(item.target)} days</strong></li>)}
+			</ul>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.3s">
+			<span class="home-card-label">Card 04</span>
+			<h2>基本信息</h2>
+			<div style="display:grid;grid-template-columns:92px 1fr;row-gap:6px;">
+				<span>Name</span><strong>Eucaly</strong>
+				<span>Age</span><strong>16</strong>
+				<span>MBTI</span><strong>ENTP</strong>
+				<span>Hobby</span><strong>Drawing, Coding</strong>
+			</div>
+			<div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap;">
+				<span class="site-chip">Dreamer</span><span class="site-chip">Student</span><span class="site-chip">Creator</span>
+			</div>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.4s">
+			<span class="home-card-label">Card 05</span>
+			<h2>正在输入</h2>
+			<div style="display:flex; gap:14px; align-items:center;">
+				<div class="iv-drop"></div>
+				<div>
+					<p><strong>Now Playing:</strong> Clancy - Twenty One Pilots</p>
+					<p><strong>Now Reading:</strong> The Midnight Library</p>
+				</div>
+			</div>
+		</article>
+
+		<a class="site-card fade-stagger" href="/memos/" style="animation-delay:.5s;background:#e6f0f5;">
+			<span class="home-card-label">Card 06</span>
+			<h2>最近状态</h2>
+			<p id="home-status-latest">Loading latest status...</p>
+		</a>
+
+		<article class="site-card fade-stagger" style="animation-delay:.6s">
+			<span class="home-card-label">Card 07</span>
+			<h2>最新动态</h2>
+			<p>📎 Last blog update: {latestPost?.data.publishDate.toLocaleDateString("en-US") ?? "N/A"}</p>
+			<p>📝 Updated posts: {posts.length}</p>
+			<p>💬 New comments: 0</p>
+			<p>🏅 Tiny achievements: 3</p>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.7s">
+			<span class="home-card-label">Card 08</span>
+			<h2>最近收藏</h2>
+			<ul>
+				{collections.map((item) => <li><a href={item.url} target="_blank" rel="noreferrer" title={item.url}>{item.icon} {item.name}</a></li>)}
+			</ul>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.8s">
+			<span class="home-card-label">Card 09</span>
+			<h2>随身小物</h2>
+			<div style="border:1px dashed #c7e9f0;border-radius:12px;padding:10px;">
+				<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px;">
+					{apps.map((app) => <div style="text-align:center;">📱<br />{app}</div>)}
+				</div>
+				<p style="margin-top:10px;">Recent purchase: {purchase}</p>
+			</div>
+		</article>
+
+		<article class="site-card fade-stagger" style="animation-delay:.9s">
+			<span class="home-card-label">Card 10</span>
+			<h2>想法</h2>
+			<p>Build softly, rest slowly, and keep creating one tiny joy each day.</p>
+			<div style="text-align:right;font-size:22px;">🪽</div>
+		</article>
 	</section>
 </PageLayout>
 
-<script define:vars={{ typingText, statusCafeAtomUrl, statusImages }} is:inline>
-	const qinhuangdao = { lat: 39.9354, lon: 119.5996 }; // 定义秦皇岛经纬度。
-	const statusProxyUrl = (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`; // 定义状态源代理地址。
-	const parseStatusFeed = (xmlText) => [...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)].map((entry) => { // 解析 Atom 条目。
-		const body = entry[1] ?? ""; // 提取条目主体。
-		const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? ""; // 提取更新时间。
-		const content = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1]?.replace(/&lt;/g, "<")?.replace(/&gt;/g, ">")?.replace(/&amp;/g, "&")?.replace(/<[^>]*>/g, " ")?.replace(/\s+/g, " ")?.trim() ?? ""; // 提取正文文本。
-		if (!content || Number.isNaN(new Date(updated).valueOf())) return null; // 过滤无效数据。
-		return { updated, content }; // 返回有效状态。
-	}).filter(Boolean); // 过滤空值。
-
-	const fetchStatusFeedText = async () => { // 拉取状态流文本。
-		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`; // 拼接防缓存地址。
-		const direct = await fetch(feedUrl, { cache: "no-store" }).catch(() => null); // 先尝试直连。
-		if (direct?.ok) return direct.text(); // 直连成功直接返回。
-		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" }); // 直连失败走代理。
-		if (!viaProxy.ok) throw new Error("status feed unavailable"); // 代理失败抛错。
-		return viaProxy.text(); // 返回代理结果。
-	};
-
-	const updateDistance = async () => { // 更新访问者到秦皇岛距离。
-		const distanceTarget = document.getElementById("home-distance"); // 获取距离文本节点。
-		if (!distanceTarget) return; // 无节点则退出。
-		try { // 尝试定位。
-			const position = await new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(resolve, reject)); // 获取定位。
-			const lat = position.coords.latitude; // 读取纬度。
-			const lon = position.coords.longitude; // 读取经度。
-			const toRad = (deg) => (deg * Math.PI) / 180; // 定义角度转弧度。
-			const dLat = toRad(qinhuangdao.lat - lat); // 计算纬度差。
-			const dLon = toRad(qinhuangdao.lon - lon); // 计算经度差。
-			const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat)) * Math.cos(toRad(qinhuangdao.lat)) * Math.sin(dLon / 2) ** 2; // 套用 haversine 公式。
-			const distanceKm = 6371 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)); // 计算公里数。
-			distanceTarget.textContent = `You are ${Math.round(distanceKm)} km away from An-chan.`; // 渲染距离文本。
-		} catch {
-			distanceTarget.textContent = "You are ... km away from An-chan."; // 定位失败显示默认文案。
-		}
-	};
-	
-	const initHome = async () => { // 初始化首页动态内容。
-		const statusDate = document.getElementById("home-status-date"); // 获取状态日期节点。
-		const statusContent = document.getElementById("home-status-content"); // 获取状态内容节点。
-		const typingTarget = document.getElementById("home-typing"); // 获取打字节点。
-		// @ts-ignore define:vars 会注入 typingText。
-		if (typingTarget) typingTarget.textContent = typingText; // 设置打字标题。
-		await updateDistance(); // 更新地理距离。
+<script is:inline>
+	const initHomeStatus = async () => {
+		const target = document.getElementById("home-status-latest");
+		if (!target) return;
 		try {
-			const items = parseStatusFeed(await fetchStatusFeedText()); // 拉取并解析状态流。
-			const first = items[0]; // 读取第一条。
-			if (first && statusDate && statusContent) { // 只有节点存在才写入。
-				statusDate.textContent = new Date(first.updated).toLocaleString("zh-CN"); // 写入时间。
-				statusContent.textContent = first.content; // 写入内容。
-			}
+			const url = "https://status.cafe/users/isntbunny.atom";
+			const raw = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`).then((res) => res.text());
+			const entry = raw.match(/<entry>([\s\S]*?)<\/entry>/i)?.[1] ?? "";
+			const content = entry.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "";
+			target.textContent = content.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim() || "No status yet.";
 		} catch {
-			if (statusContent) statusContent.textContent = "Unable to load status.cafe feed right now."; // 失败提示。
+			target.textContent = "Unable to load status for now.";
 		}
-		const sideImage = document.getElementById("home-status-side-image"); // 获取侧边图节点。
-		if (sideImage instanceof HTMLImageElement) sideImage.src = statusImages[Math.floor(Math.random() * statusImages.length)] ?? statusImages[0]; // 随机切换侧边图。
 	};
-	document.addEventListener("astro:page-load", initHome); // 页面切换后重跑初始化。
-	initHome(); // 首次进入立即初始化。
+	document.addEventListener("astro:page-load", initHomeStatus);
+	initHomeStatus();
 </script>

--- a/src/pages/memos/[...page].astro
+++ b/src/pages/memos/[...page].astro
@@ -3,57 +3,73 @@ import type { GetStaticPaths } from "astro";
 import PageLayout from "@/layouts/Base.astro";
 
 export const getStaticPaths = (async ({ paginate }) => paginate([0], { pageSize: 1 })) satisfies GetStaticPaths;
-const statusCafeAtomUrl = "https://status.cafe/users/isntbunny.atom";
 ---
 
 <PageLayout meta={{ description: "status.cafe stream", title: "Memos" }}>
-	<section class="memos-page-layout">
-		<header class="memos-page-header"><h1 class="title">Memos</h1><p>这里只保留 status.cafe 内容。</p></header>
-		<section aria-labelledby="status-feed-title" class="memos-panel-section">
-			<h2 class="memos-panel-title" id="status-feed-title">STATUS CAFE STREAM</h2>
-			<div class="memos-status-stream-grid" id="statuscafe-stream" role="feed"></div>
-		</section>
+	<section class="memo-flow">
+		<h1>Memos</h1>
+		<div id="memo-list"></div>
+		<button class="memo-loadmore" id="memo-loadmore" type="button">Load more</button>
 	</section>
 </PageLayout>
 
-<script define:vars={{ statusCafeAtomUrl }} is:inline>
-	const statusProxyUrl = (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`; // 定义代理地址。
-	const decodeHtmlText = (text) => { // 定义 HTML 解码函数。
-		const doc = new DOMParser().parseFromString(text, "text/html"); // 解析 HTML。
-		return doc.documentElement.textContent ?? ""; // 返回纯文本。
+<script is:inline>
+	const PAGE_SIZE = 20;
+	let renderedCount = 0;
+	let memoItems = [];
+
+	const parseStatusFeed = (xmlText) => [...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)].map((entry) => {
+		const body = entry[1] ?? "";
+		const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? "";
+		const content = (body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "")
+			.replace(/<[^>]*>/g, " ")
+			.replace(/\s+/g, " ")
+			.trim();
+		if (!content || Number.isNaN(new Date(updated).valueOf())) return null;
+		return { updated, content };
+	}).filter(Boolean);
+
+	const renderBatch = () => {
+		const list = document.getElementById("memo-list");
+		const more = document.getElementById("memo-loadmore");
+		if (!list || !more) return;
+		const batch = memoItems.slice(renderedCount, renderedCount + PAGE_SIZE);
+		list.insertAdjacentHTML(
+			"beforeend",
+			batch.map((item) => `
+				<article class="memo-item">
+					<div class="memo-time-line"></div>
+					<div class="site-card">
+						<time class="memo-time">${new Date(item.updated).toLocaleString("en-US")}</time>
+						<p class="memo-content">${item.content}</p>
+						<div class="memo-actions"><button type="button">↩ Reply</button><button type="button">♡ Like</button></div>
+					</div>
+				</article>
+			`).join(""),
+		);
+		renderedCount += batch.length;
+		if (renderedCount >= memoItems.length) more.setAttribute("hidden", "hidden");
 	};
-	const parseStatusFeed = (xmlText) => [...xmlText.matchAll(/<entry>([\s\S]*?)<\/entry>/gi)].map((entry) => { // 解析状态条目。
-		const body = entry[1] ?? ""; // 提取条目主体。
-		const id = body.match(/<id>([\s\S]*?)<\/id>/i)?.[1]?.trim() ?? ""; // 提取条目 ID。
-		const updated = body.match(/<updated>([\s\S]*?)<\/updated>/i)?.[1]?.trim() ?? ""; // 提取更新时间。
-		const contentRaw = body.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? ""; // 提取原始内容。
-		const content = decodeHtmlText(contentRaw).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim(); // 转换为纯文本内容。
-		if (!id || !content || Number.isNaN(new Date(updated).valueOf())) return null; // 过滤非法条目。
-		return { id, content, updated }; // 返回合法条目。
-	}).filter(Boolean); // 去除空值。
-	const fetchStatusFeedText = async () => { // 拉取状态流 XML。
-		const feedUrl = `${statusCafeAtomUrl}?t=${Date.now()}`; // 添加时间戳防缓存。
-		const direct = await fetch(feedUrl, { cache: "no-store" }).catch(() => null); // 先尝试直连。
-		if (direct?.ok) return direct.text(); // 直连成功返回内容。
-		const viaProxy = await fetch(statusProxyUrl(feedUrl), { cache: "no-store" }); // 直连失败改用代理。
-		if (!viaProxy.ok) throw new Error("status feed unavailable"); // 代理失败抛错。
-		return viaProxy.text(); // 返回代理文本。
-	};
-	const renderStatusFeed = async () => { // 渲染状态流到页面。
-		const statusFeedContainer = document.getElementById("statuscafe-stream"); // 获取容器节点。
-		if (!statusFeedContainer) return; // 缺失容器时退出。
+
+	const initMemos = async () => {
+		const more = document.getElementById("memo-loadmore");
+		if (!more) return;
 		try {
-			const items = parseStatusFeed(await fetchStatusFeedText()); // 拉取并解析条目。
-			statusFeedContainer.innerHTML = items.map((item) => `<article class="status-card memos-status-stream-item"><time>${new Date(item.updated).toLocaleString("zh-CN")}</time><p>${item.content}</p></article>`).join(""); // 渲染条目列表。
+			const url = "https://status.cafe/users/isntbunny.atom";
+			const raw = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`).then((res) => res.text());
+			memoItems = parseStatusFeed(raw);
+			renderedCount = 0;
+			document.getElementById("memo-list").innerHTML = "";
+			renderBatch();
 		} catch {
-			statusFeedContainer.innerHTML = `<p class="status-card">Unable to load status.cafe stream right now.</p>`; // 失败时渲染错误提示。
+			document.getElementById("memo-list").innerHTML = `<p class="site-card">Unable to load status feed right now.</p>`;
+			more.setAttribute("hidden", "hidden");
+		}
+		if (more.dataset.bound !== "1") {
+			more.dataset.bound = "1";
+			more.addEventListener("click", renderBatch);
 		}
 	};
-	const initStatusStream = () => { // 初始化并轮询状态流。
-		renderStatusFeed(); // 首次执行渲染。
-		if (window.__statusStreamTimer) clearInterval(window.__statusStreamTimer); // 清除已有定时器。
-		window.__statusStreamTimer = setInterval(renderStatusFeed, 45000); // 建立 45 秒轮询。
-	};
-	document.addEventListener("astro:page-load", initStatusStream); // 路由切换后重新初始化。
-	initStatusStream(); // 首屏立即初始化。
+	document.addEventListener("astro:page-load", initMemos);
+	initMemos();
 </script>

--- a/src/pages/memos/[slug].astro
+++ b/src/pages/memos/[slug].astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect('/memos/');
----

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -43,6 +43,7 @@ export const siteConfig: SiteConfig & { backgroundImage: string; bangumiUsername
 // Used to generate links in both the Header & Footer.
 export const menuLinks: MenuLink[] = [
 	{ path: "/posts/", title: "Blog" },
+	{ path: "/archive/", title: "Archive" },
 	{ path: "/memos/", title: "Memos" },
 	{ path: "/gallery/", title: "Gallery" },
 	{ path: "/guestbook/", title: "Guestbook" },

--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -1,140 +1,82 @@
-.card-chip {
-	border-radius: 0.125rem;
-	padding: 0.25rem 0.5rem;
-	transition: all 0.2s ease;
+.home-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 24px;
 }
 
-.home-top-image {
-	width: 100%;
-	height: 140px;
-	object-fit: cover;
-	border: 1px solid #4a78d0;
+@media (max-width: 980px) {
+	.home-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
-.win-card {
-	border: 1px solid #7e8faa;
-	background: #c9d7e8;
+@media (max-width: 680px) {
+	.home-grid { grid-template-columns: 1fr; }
 }
 
-.win-title-bar {
-	background: linear-gradient(90deg, #355ca5, #91b2ec);
-	color: #ffffff;
-	font-size: 0.72rem;
-	letter-spacing: 0.06em;
-	padding: 0.3rem 0.5rem;
+.home-card-label {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 4px;
+	font-size: 12px;
+	background: #c7e9f0;
+	color: #4a5568;
+	margin-bottom: 8px;
+}
+
+.home-countdown-list li {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	padding: 4px 0;
+	border-bottom: 1px dashed #c7e9f0;
 }
 
-.win-body {
-	color: #2d3a4a;
-	padding: 0.7rem;
+.thermometer {
+	height: 140px;
+	width: 20px;
+	border-radius: 20px;
+	border: 1px solid #e2e8f0;
+	padding: 2px;
+	position: relative;
+	background: #f7fcff;
 }
 
-.home-welcome-jump {
-	animation: jump 0.7s infinite alternate ease-in-out;
+.thermometer::before {
+	content: "";
+	position: absolute;
+	inset: auto 2px 2px;
+	height: 68%;
+	background: #c7e9f0;
+	border-radius: 10px;
 }
 
-.home-main-grid {
-	display: table;
-	width: 100%;
-	border-spacing: 0.85rem 0;
+.iv-drop {
+	width: 22px;
+	height: 48px;
+	border: 1px solid #c7e9f0;
+	border-radius: 0 0 11px 11px;
+	position: relative;
+}
+.iv-drop::after {
+	content: "";
+	position: absolute;
+	left: 7px;
+	top: 8px;
+	width: 6px;
+	height: 10px;
+	border-radius: 999px;
+	background: #c7e9f0;
+	animation: drop 3s infinite;
+}
+@keyframes drop {
+	0% { transform: translateY(0); opacity: 0; }
+	20% { opacity: 1; }
+	100% { transform: translateY(26px); opacity: 0; }
 }
 
-.home-main-grid > * {
-	display: table-cell;
-	vertical-align: top;
+.fade-stagger {
+	opacity: 0;
+	animation: cardIn 0.5s ease forwards;
 }
-
-.home-main-grid > .shared-left-sidebar,
-.home-main-grid > .home-right-rail {
-	width: 24%;
-}
-
-.home-main-grid > .home-middle-column {
-	width: 52%;
-}
-
-.home-sidebar-frame {
-	border: 1px solid #4a78d0;
-	padding: 0.6rem;
-}
-
-.home-layout-column {
-	display: flex;
-	flex-direction: column;
-	gap: 0.55rem;
-}
-
-.home-middle-column {
-	display: grid;
-	gap: 0.8rem;
-}
-
-.home-image-grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 0.7rem;
-}
-
-.home-image-placeholder {
-	min-height: 150px;
-	border: 1px dashed #4a78d0;
-	background: #eff7ffb3;
-	display: grid;
-	place-items: center;
-	font-size: 0.74rem;
-	letter-spacing: 0.06em;
-	text-align: center;
-	padding: 0.6rem;
-}
-
-.home-image-placeholder--wide {
-	grid-column: span 2;
-	min-height: 180px;
-}
-
-.home-right-card + .home-right-card {
-	border-top: 1px dashed #7e8faa;
-	padding-top: 0.6rem;
-}
-
-.home-right-card h2 {
-	font-size: 0.74rem;
-	letter-spacing: 0.08em;
-	font-weight: 700;
-	margin-bottom: 0.35rem;
-}
-
-.home-right-card img {
-	width: 100%;
-	cursor: pointer;
-	border: 1px solid #7e8faa;
-}
-
-.angel-divider { text-align: center; font-size: 0.78rem; color: #46608f; line-height: 1; }
-.win-enter-btn { border: 1px solid #7e8faa; background: #e8f2ff; padding: 0.15rem 0.5rem; font-size: 0.72rem; }
-.card-enter-wrap { display: flex; align-items: center; justify-content: space-between; gap: 0.65rem; }
-
-@media (max-width: 1023px) {
-	.home-main-grid,
-	.home-main-grid > * {
-		display: block;
-		width: 100%;
-	}
-
-	.home-main-grid > * + * {
-		margin-top: 0.85rem;
-	}
-}
-
-@media (max-width: 640px) {
-	.home-image-grid {
-		grid-template-columns: 1fr;
-	}
-
-	.home-image-placeholder--wide {
-		grid-column: span 1;
-	}
+@keyframes cardIn {
+	from { opacity: 0; transform: translateY(10px); }
+	to { opacity: 1; transform: translateY(0); }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,3 +32,31 @@
 		transform: translate(-50%, -160%) scale(1.25);
 	}
 }
+
+/* Custom page styles */
+.gallery-grid { display:grid; gap:24px; grid-template-columns:repeat(4,minmax(0,1fr)); }
+.sections-grid { grid-template-columns:repeat(3,minmax(0,1fr)); }
+.gallery-image { width:100%; aspect-ratio:16/9; object-fit:cover; border-radius:12px; display:block; opacity:0; animation: imgFade .4s ease forwards; }
+@keyframes imgFade { to { opacity:1; } }
+.gallery-tile { cursor:pointer; position:relative; }
+.gallery-skeleton { position:absolute; inset:20px; border-radius:12px; background:linear-gradient(90deg,#d4f0f5,#e8f6fa,#d4f0f5); background-size:200% 100%; animation: shimmer 1.2s infinite; }
+@keyframes shimmer { from{background-position:200% 0;} to{background-position:-200% 0;} }
+.gallery-lightbox { position:fixed; inset:0; z-index:300; background:rgba(0,0,0,.6); display:grid; grid-template-columns:60px minmax(0,1fr) 60px; align-items:center; gap:10px; padding:24px; }
+.gallery-lightbox img { max-width:min(920px,100%); max-height:76vh; margin:auto; display:block; border-radius:12px; }
+.gallery-lightbox p { color:#fff; text-align:center; }
+.gallery-arrow { border:1px solid rgba(255,255,255,.4); background:rgba(255,255,255,.1); color:#fff; border-radius:20px; padding:10px; }
+
+.bangumi-tabs { display:flex; justify-content:center; gap:16px; margin-bottom:18px; }
+.bangumi-tab { background:transparent; border:0; color:#a0aec0; padding:2px 0; }
+.bangumi-tab.is-active { color:#c7e9f0; border-bottom:2px solid #c7e9f0; }
+.bangumi-grid { display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:16px; }
+.bangumi-item img { width:100%; aspect-ratio:3/4; object-fit:cover; border-radius:8px; transition:.3s; }
+.bangumi-item h3 { font-size:14px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; margin:8px 0 2px; }
+.bangumi-item:hover img { transform:translateY(-2px); box-shadow:0 8px 20px rgba(199,233,240,.3); }
+
+#waline .wl-editor, #waline .wl-input, #waline .wl-card { border-radius:12px !important; border:1px solid #e2e8f0 !important; }
+#waline .wl-btn.primary { border-radius:20px !important; background:#c7e9f0 !important; color:#4a5568 !important; border:1px solid #e2e8f0 !important; }
+
+@media (max-width: 1100px) { .bangumi-grid{grid-template-columns:repeat(4,minmax(0,1fr));} .gallery-grid{grid-template-columns:repeat(3,minmax(0,1fr));} }
+@media (max-width: 900px) { .gallery-grid,.sections-grid{grid-template-columns:repeat(2,minmax(0,1fr));} }
+@media (max-width: 640px) { .bangumi-grid,.gallery-grid,.sections-grid{grid-template-columns:1fr 1fr;} }

--- a/src/styles/layout/base.css
+++ b/src/styles/layout/base.css
@@ -1,94 +1,128 @@
+:root {
+	--primary-100: #e1f5f8;
+	--primary-200: #d4f0f5;
+	--primary-300: #c7e9f0;
+	--bg-main: #f0f7fa;
+	--text-main: #4a5568;
+	--text-muted: #a0aec0;
+	--white: #ffffff;
+	--border: #e2e8f0;
+	--card-shadow: 0 4px 12px rgba(0, 0, 0, 0.02);
+	--hover-shadow: 0 8px 20px rgba(199, 233, 240, 0.3);
+}
+
+* { box-sizing: border-box; }
+
 body.site-shell {
-	margin: 0 auto;
-	display: flex;
+	margin: 0;
 	min-height: 100vh;
-	width: 100%;
-	max-width: 96rem;
-	flex-direction: column;
-	padding: 1.5rem 0.75rem 0;
-	font-size: 1rem;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 	font-weight: 400;
-	background-repeat: no-repeat;
-	background-size: cover;
-	background-position: center;
-	background-attachment: scroll;
+	line-height: 1.8;
+	color: var(--text-main);
+	background: repeating-linear-gradient(
+		90deg,
+		var(--bg-main) 0,
+		var(--bg-main) 39px,
+		rgba(255, 255, 255, 0.03) 39px,
+		rgba(255, 255, 255, 0.03) 40px
+	);
 }
 
-@media (min-width: 640px) {
-	body.site-shell {
-		padding: 2rem 1.5rem 0;
-		background-attachment: fixed;
-	}
+main#main {
+	width: min(1120px, calc(100% - 2rem));
+	margin: 108px auto 0;
+	padding-bottom: 32px;
 }
 
-.site-hero-strip {
-	position: relative;
-	z-index: 10;
-	display: grid;
-	gap: 0.5rem;
-	margin-bottom: 0.75rem;
+h1, h2, h3, h4, h5, h6 { font-weight: 500; line-height: 1.4; color: var(--text-main); }
+.small-muted { font-weight: 300; color: var(--text-muted); }
+
+a { color: var(--text-main); text-decoration: none; }
+
+.site-card {
+	border-radius: 12px;
+	background: var(--white);
+	border: 1px solid var(--border);
+	box-shadow: var(--card-shadow);
+	backdrop-filter: blur(6px);
+	padding: 20px;
+	transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.inner-page-shell {
-	display: grid;
-	gap: 0.85rem;
+.site-card:hover { transform: translateY(-2px); box-shadow: var(--hover-shadow); }
+
+.site-chip {
+	display: inline-flex;
+	padding: 2px 10px;
+	border-radius: 30px;
+	border: 1px solid var(--primary-300);
+	font-size: 12px;
 }
 
-.inner-page-content {
-	padding: 0.85rem 1rem;
-	border: 1px solid #4a78d0;
-	background: #eef6ff94;
-}
-
-@media (min-width: 1024px) {
-	.inner-page-shell {
-		grid-template-columns: 0.65fr 2.05fr;
-	}
-}
-
-.site-action-rail {
+#main-header {
 	position: fixed;
-	top: 1rem;
-	right: max(0.75rem, calc((100vw - 88rem) / 2 + 0.75rem));
-	z-index: 80;
-	display: grid;
-	gap: 0.35rem;
+	inset: 0 0 auto 0;
+	z-index: 120;
+	padding: 16px 24px;
+	transition: background-color 0.3s ease, backdrop-filter 0.3s ease, box-shadow 0.3s ease;
 }
 
-.site-action-rail > * {
-	border: 1px solid #7e8faa;
-	background: #dce8f8e6;
-	padding: 0.22rem;
+#main-header.is-scrolled {
+	background: rgba(255, 255, 255, 0.8);
+	backdrop-filter: blur(8px);
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.02);
 }
 
-#global-lightbox {
+.site-nav-shell {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 24px;
+	max-width: 1120px;
+	margin: 0 auto;
+}
+
+.site-logo { font-weight: 500; }
+.site-nav-links { display: flex; flex-wrap: wrap; gap: 24px; }
+.site-nav-link { position: relative; color: var(--text-main); }
+.site-nav-link:hover { color: var(--primary-300); }
+.site-nav-link[aria-current="page"]::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: -8px;
+	height: 2px;
+	background: var(--primary-300);
+}
+
+.site-footer {
+	padding: 40px 0;
+	text-align: center;
+	font-size: 14px;
+	color: var(--text-muted);
+	border-top: 1px solid var(--border);
+}
+
+.page-fade { animation: pageFade 0.3s ease both; }
+@keyframes pageFade { from { opacity: 0; } to { opacity: 1; } }
+
+.initial-loader {
 	position: fixed;
 	inset: 0;
-	z-index: 300;
-	display: none;
-	align-items: center;
-	justify-content: center;
-	background: #000000d1;
-	padding: 1rem;
+	z-index: 400;
+	display: grid;
+	place-items: center;
+	background: rgba(240, 247, 250, 0.96);
+	transition: opacity 0.4s ease;
 }
+.initial-loader__icon { font-size: 48px; animation: spin 2s linear; }
+.initial-loader--hidden { opacity: 0; pointer-events: none; }
+@keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }
 
-#global-lightbox[data-open="true"] {
-	display: flex;
-}
-
-#global-lightbox img {
-	max-height: 92vh;
-	max-width: 92vw;
-	object-fit: contain;
-}
-
-.click-kaomoji-effect {
-	position: fixed;
-	z-index: 999;
-	pointer-events: none;
-	font-size: 0.8rem;
-	color: #3a5066;
-	text-shadow: 0 0 4px #ffffff;
-	transform: translate(-50%, -50%);
-	animation: kaomoji-pop 0.9s ease-out forwards;
+@media (max-width: 720px) {
+	main#main { width: calc(100% - 1.2rem); margin-top: 92px; }
+	#main-header { padding: 14px 12px; }
+	.site-nav-links { gap: 16px; }
 }

--- a/src/styles/pages/about.css
+++ b/src/styles/pages/about.css
@@ -1,28 +1,13 @@
-.about-readme-shell {
-	display: grid;
-	gap: 1rem;
-	align-items: start;
-}
-
-@media (min-width: 900px) {
-	.about-readme-shell {
-		grid-template-columns: 1.6fr 220px;
-	}
-}
-
-.about-avatar-wrap {
-	width: 220px;
-	height: 220px;
-	max-width: 100%;
-	margin-inline: auto;
-	border-radius: 999px;
-	overflow: hidden;
-	border: 1px solid #4a78d0;
-	background: #ffffffb3;
-}
-
-.about-avatar-wrap img {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-}
+.about-grid { display:grid; grid-template-columns: 240px 1fr; gap:24px; align-items:center; }
+.about-avatar { width:120px; height:120px; border-radius:50%; object-fit:cover; }
+.about-name { font-size:24px; margin:0; }
+.about-bio { font-size:14px; color:#4a5568; line-height:1.8; }
+.about-social { display:flex; gap:12px; margin-top:12px; }
+.about-social a:hover { color:#c7e9f0; }
+.skills { margin-top:24px; display:grid; gap:14px; }
+.skill-row { display:grid; grid-template-columns: 120px 1fr 48px; gap:12px; align-items:center; }
+.skill-bar { height:6px; border-radius:30px; background:#e2e8f0; overflow:hidden; }
+.skill-fill { display:block; height:100%; background:#c7e9f0; width:0; transition:width 0.8s ease; }
+.about-avatar-spin { animation: avatarspin 3s linear; }
+@keyframes avatarspin { from {transform:rotate(0deg);} to {transform:rotate(360deg);} }
+@media (max-width: 720px) { .about-grid { grid-template-columns:1fr; } }

--- a/src/styles/pages/memos.css
+++ b/src/styles/pages/memos.css
@@ -1,33 +1,11 @@
-.memos-page-layout {
-	display: grid;
-	gap: 1rem;
-	letter-spacing: 0.05em;
-}
-
-.memos-page-header,
-.memos-panel-section {
-	display: grid;
-	gap: 0.65rem;
-}
-
-.memos-panel-title {
-	font-size: 0.8rem;
-	font-weight: 700;
-	letter-spacing: 0.12em;
-}
-
-.memos-status-stream-grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 0.8rem;
-}
-
-.memos-status-stream-item {
-	border: 1px solid #7e8faa;
-}
-
-@media (max-width: 700px) {
-	.memos-status-stream-grid {
-		grid-template-columns: 1fr;
-	}
-}
+.memo-flow { max-width: 860px; margin: 0 auto; }
+.memo-item { display: grid; grid-template-columns: 40px 1fr; gap: 12px; margin-bottom: 16px; }
+.memo-time-line { position: relative; }
+.memo-time-line::before { content:""; position:absolute; left:18px; top:0; bottom:-16px; width:2px; background:#c7e9f0; }
+.memo-time-line::after { content:""; position:absolute; left:13px; top:8px; width:12px; height:12px; border-radius:999px; background:#c7e9f0; }
+.memo-time { font-size:12px; color:#a0aec0; }
+.memo-content { font-size:14px; color:#4a5568; }
+.memo-actions { margin-top:10px; display:flex; gap:14px; font-size:14px; color:#a0aec0; }
+.memo-actions button { border:0; background:transparent; cursor:pointer; color:inherit; }
+.memo-actions button:hover { color:#c7e9f0; }
+.memo-loadmore { display:block; margin: 8px auto 0; border:1px solid #e2e8f0; border-radius:20px; padding:8px 16px; background:#c7e9f0; color:#4a5568; }


### PR DESCRIPTION
### Motivation
- Introduce a cohesive pastel, soft UI system and unified layout behaviors (fixed translucent navbar, page transitions, loader) to match the provided design spec. 
- Replace fragmented page templates with responsive, card-based pages (home, gallery, bangumi, about, memos, guestbook) and add an archive view for better content discovery. 
- Make memos a client-driven timeline with pagination and ensure static build compatibility by removing an unused dynamic slug route. 

### Description
- Implemented a global visual system and layout changes via `src/styles/layout/base.css` and `src/styles/global.css`, added tokens for palette, typography, radii, borders, and shadows, plus loader and page-fade animations. 
- Reworked the shared shell and navigation: `src/layouts/Base.astro` now provides the initial wing loader, page fade behavior, and uses the new `Header`/`Footer` components (`src/components/layout/Header.astro`, `src/components/layout/Footer.astro`). 
- Rebuilt pages and components: `src/pages/index.astro` replaced with a responsive 10-card dashboard and staggered animations, `src/pages/archive.astro` added for year/month grouping, `src/pages/memos/[...page].astro` reworked into a timeline with batch `Load more` (20 items) fetching from `status.cafe`, gallery pages (`src/pages/gallery/*`) get skeleton loaders and a lightbox, bangumi and about pages refreshed, and guestbook switched to `Waline` (`src/components/Waline.astro` styled to match). 
- Site config/menu updated (`src/site.config.ts`) to include the new `Archive` route, and the obsolete dynamic route `src/pages/memos/[slug].astro` was removed to avoid static-build routing errors. 

### Testing
- Ran `npm run build`, addressed an initial dynamic-route error, and re-ran the build successfully; the final build completed without errors. 
- Post-build indexing (`pagefind` run during `postbuild`) executed and completed successfully as part of the build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba572c4ca8832cb89f59a550f15190)