### PR TITLE
feat(home): layered sticker-style homepage scene with overlap placeholders

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -4,23 +4,29 @@ import { menuLinks } from "@/site.config";
 const navItems = menuLinks.flatMap((link) =>
 	link.children?.length ? link.children : [link],
 ).filter((item) => item.path);
+
+const isHome = Astro.url.pathname === "/";
 ---
 
 <header id="main-header">
 	<nav aria-label="Main menu" class="site-nav-shell">
 		<a class="site-logo" href="/">Eucaly's Blog</a>
-		<div class="site-nav-links">
-			{navItems.map((link) => (
-				<a
-					aria-current={Astro.url.pathname === link.path ? "page" : false}
-					class="site-nav-link"
-					href={link.path}
-					target={link.external ? "_blank" : undefined}
-					rel={link.external ? "noreferrer" : undefined}
-				>
-					{link.title}
-				</a>
-			))}
-		</div>
+		{isHome ? (
+			<h1 class="site-home-title">Eucaly's Blog</h1>
+		) : (
+			<div class="site-nav-links">
+				{navItems.map((link) => (
+					<a
+						aria-current={Astro.url.pathname === link.path ? "page" : false}
+						class="site-nav-link"
+						href={link.path}
+						target={link.external ? "_blank" : undefined}
+						rel={link.external ? "noreferrer" : undefined}
+					>
+						{link.title}
+					</a>
+				))}
+			</div>
+		)}
 	</nav>
 </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,133 +1,45 @@
 ---
-import { getCollection } from "astro:content";
 import PageLayout from "@/layouts/Base.astro";
-
-const posts = await getCollection("post", ({ data }) => !data.draft);
-const latestPost = posts.sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())[0];
-const countdownTargets = [
-	{ label: "Month End", target: new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0) },
-	{ label: "Next Year", target: new Date(new Date().getFullYear() + 1, 0, 1) },
-	{ label: "Gaokao 2027", target: new Date("2027-06-07T00:00:00+08:00") },
-];
-const daysLeft = (target: Date) => Math.max(0, Math.ceil((target.getTime() - Date.now()) / 86400000));
-
-const collections = [
-	{ name: "GitHub", icon: "🐙", url: "https://github.com/isntbunny" },
-	{ name: "Bangumi", icon: "📺", url: "https://bgm.tv/user/isntbunny" },
-	{ name: "Status Cafe", icon: "☕", url: "https://status.cafe/users/isntbunny" },
-];
-
-const apps = ["Notion", "VS Code", "Spotify"];
-const purchase = "A new pastel notebook";
 ---
 
 <PageLayout meta={{ title: "Home" }}>
-	<section class="home-grid">
-		<article class="site-card fade-stagger" style="animation-delay:0s">
-			<h2>今日状态</h2>
-			<div style="display:flex; gap:16px; align-items:center;">
-				<div class="thermometer"></div>
-				<ul>
-					<li>Mood Temp: <strong>36.5°C</strong></li>
-					<li>Energy: <strong>82%</strong></li>
-					<li>Inspiration: <strong>74%</strong></li>
-				</ul>
-			</div>
-		</article>
+	<section class="scene-home">
+		<div aria-hidden="true" class="scene-desktop"></div>
+		<div aria-hidden="true" class="scene-corner"></div>
 
-		<article class="site-card fade-stagger" style="animation-delay:.1s">
-			<h2>我的待办</h2>
-			<div style="font-size:20px;">℞</div>
-			<ul>
-				<li>Finish today’s reading note.</li>
-				<li>Reply to important messages.</li>
-				<li>Update one tiny page detail.</li>
-			</ul>
-		</article>
-
-		<article class="site-card fade-stagger" style="animation-delay:.2s">
-			<h2>倒计时</h2>
-			<ul class="home-countdown-list">
-				{countdownTargets.map((item) => <li><span>{item.label}</span><strong>{daysLeft(item.target)} days</strong></li>)}
-			</ul>
-		</article>
-
-		<article class="site-card fade-stagger" style="animation-delay:.3s">
-			<h2>基本信息</h2>
-			<div style="display:grid;grid-template-columns:92px 1fr;row-gap:6px;">
-				<span>Name</span><strong>Eucaly</strong>
-				<span>Age</span><strong>16</strong>
-				<span>MBTI</span><strong>ENTP</strong>
-				<span>Hobby</span><strong>Drawing, Coding</strong>
-			</div>
-			<div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap;">
-				<span class="site-chip">Dreamer</span><span class="site-chip">Student</span><span class="site-chip">Creator</span>
-			</div>
-		</article>
-
-		<article class="site-card fade-stagger" style="animation-delay:.4s">
-			<h2>正在输入</h2>
-			<div style="display:flex; gap:14px; align-items:center;">
-				<div class="iv-drop"></div>
-				<div>
-					<p><strong>Now Playing:</strong> Clancy - Twenty One Pilots</p>
-					<p><strong>Now Reading:</strong> The Midnight Library</p>
+		<div class="scene-layout">
+			<section class="wall-zone">
+				<div class="wall-card wall-card-left">
+					<div class="mini-card mini-left">左侧小卡片（5/7）</div>
+					<div class="mini-card mini-right-top">右上小卡片（1/9）</div>
+					<div class="mini-card mini-right-mid">右中小卡片（4/9）</div>
+					<div class="mini-card mini-right-bottom">右下小卡片（4/9）</div>
+					<div class="mini-card mini-overflow">溢出小卡片（4/7）</div>
 				</div>
-			</div>
-		</article>
+				<div class="wall-card wall-card-right">右侧大卡片占位（宽约 1/5 屏幕）</div>
+			</section>
 
-		<a class="site-card fade-stagger" href="/memos/" style="animation-delay:.5s;background:#e6f0f5;">
-			<h2>最近状态</h2>
-			<p id="home-status-latest">Loading latest status...</p>
-		</a>
+			<aside class="right-zone">
+				<article class="window-card">
+					<header class="window-title">Windows 卡片</header>
+					<p>这里是导航栏下方、三角形上方的窗口样式区域。</p>
+				</article>
 
-		<article class="site-card fade-stagger" style="animation-delay:.6s">
-			<h2>最新动态</h2>
-			<p>📎 Last blog update: {latestPost?.data.publishDate.toLocaleDateString("en-US") ?? "N/A"}</p>
-			<p>📝 Updated posts: {posts.length}</p>
-			<p>💬 New comments: 0</p>
-			<p>🏅 Tiny achievements: 3</p>
-		</article>
-
-		<article class="site-card fade-stagger" style="animation-delay:.7s">
-			<h2>最近收藏</h2>
-			<ul>
-				{collections.map((item) => <li><a href={item.url} target="_blank" rel="noreferrer" title={item.url}>{item.icon} {item.name}</a></li>)}
-			</ul>
-		</article>
-
-		<article class="site-card fade-stagger" style="animation-delay:.8s">
-			<h2>随身小物</h2>
-			<div style="border:1px dashed #c7e9f0;border-radius:12px;padding:10px;">
-				<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px;">
-					{apps.map((app) => <div style="text-align:center;">📱<br />{app}</div>)}
+				<div class="character-zone">
+					<div class="character-placeholder">人物图片占位符</div>
+					<div class="bubble-card">漫画气泡卡片（头部）</div>
+					<div class="overlay-card overlay-top">交错卡片 A（身体）</div>
+					<div class="overlay-card overlay-bottom">交错卡片 B（身体）</div>
 				</div>
-				<p style="margin-top:10px;">Recent purchase: {purchase}</p>
-			</div>
-		</article>
+			</aside>
+		</div>
 
-		<article class="site-card fade-stagger" style="animation-delay:.9s">
-			<h2>想法</h2>
-			<p>Build softly, rest slowly, and keep creating one tiny joy each day.</p>
-			<div style="text-align:right;font-size:22px;">🪽</div>
-		</article>
+		<section class="desktop-gallery" aria-label="桌面图片位置">
+			<div class="desk-item">图片位 1</div>
+			<div class="desk-item">图片位 2</div>
+			<div class="desk-item">图片位 3</div>
+			<div class="desk-item">图片位 4</div>
+			<div class="desk-item">图片位 5</div>
+		</section>
 	</section>
 </PageLayout>
-
-<script is:inline>
-	const initHomeStatus = async () => {
-		const target = document.getElementById("home-status-latest");
-		if (!target) return;
-		try {
-			const url = "https://status.cafe/users/isntbunny.atom";
-			const raw = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`).then((res) => res.text());
-			const entry = raw.match(/<entry>([\s\S]*?)<\/entry>/i)?.[1] ?? "";
-			const content = entry.match(/<content[^>]*>([\s\S]*?)<\/content>/i)?.[1] ?? "";
-			target.textContent = content.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim() || "No status yet.";
-		} catch {
-			target.textContent = "Unable to load status for now.";
-		}
-	};
-	document.addEventListener("astro:page-load", initHomeStatus);
-	initHomeStatus();
-</script>

--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -1,82 +1,263 @@
-.home-grid {
+.scene-home {
+	position: relative;
+	min-height: calc(100vh - 150px);
+	padding: 24px 24px 18vh;
+	overflow: hidden;
+}
+
+.scene-desktop {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 10vh;
+	background: #a8c6e8;
+	border-top: 2px solid rgba(255, 255, 255, 0.65);
+	z-index: 1;
+}
+
+.scene-corner {
+	position: absolute;
+	right: 0;
+	bottom: 10vh;
+	width: 20vw;
+	height: 20vw;
+	max-width: 320px;
+	max-height: 320px;
+	min-width: 140px;
+	min-height: 140px;
+	background: linear-gradient(135deg, #f9fbff 0%, #dfebfa 100%);
+	clip-path: polygon(100% 0, 0 100%, 100% 100%);
+	border-left: 1px solid #b9cde8;
+	border-top: 1px solid #d9e5f6;
+	z-index: 2;
+}
+
+.scene-layout {
+	position: relative;
+	z-index: 3;
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
+	grid-template-columns: minmax(0, 1fr) minmax(220px, 20vw);
 	gap: 24px;
+	align-items: start;
 }
 
-@media (max-width: 980px) {
-	.home-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.wall-zone {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(220px, 20vw);
+	gap: 20px;
+	align-items: start;
+	margin-right: 8px;
 }
 
-@media (max-width: 680px) {
-	.home-grid { grid-template-columns: 1fr; }
-}
-
-.home-card-label {
-	display: inline-block;
-	padding: 2px 8px;
-	border-radius: 4px;
-	font-size: 12px;
-	background: #c7e9f0;
-	color: #4a5568;
-	margin-bottom: 8px;
-}
-
-.home-countdown-list li {
-	display: flex;
-	justify-content: space-between;
-	padding: 4px 0;
-	border-bottom: 1px dashed #c7e9f0;
-}
-
-.thermometer {
-	height: 140px;
-	width: 20px;
-	border-radius: 20px;
-	border: 1px solid #e2e8f0;
-	padding: 2px;
+.wall-card {
 	position: relative;
-	background: #f7fcff;
+	border-radius: 16px;
+	border: 1px solid #9dbfe4;
+	background: rgba(255, 255, 255, 0.83);
+	box-shadow: 0 14px 36px rgba(72, 106, 152, 0.14);
+	padding: 20px;
+	min-height: 320px;
 }
 
-.thermometer::before {
-	content: "";
+.wall-card-left {
+	isolation: isolate;
+}
+
+.mini-card {
 	position: absolute;
-	inset: auto 2px 2px;
-	height: 68%;
-	background: #c7e9f0;
+	border: 1px solid #b8cde8;
+	border-radius: 12px;
+	background: #f6faff;
+	box-shadow: 0 8px 20px rgba(89, 124, 170, 0.12);
+	padding: 10px;
+	font-size: 13px;
+}
+
+.mini-left {
+	left: 14px;
+	top: 14px;
+	width: calc(100% * 5 / 7);
+	height: 42%;
+}
+
+.mini-right-top {
+	right: 14px;
+	top: 14px;
+	width: calc(100% * 2 / 7 - 14px);
+	height: calc(100% / 9);
+}
+
+.mini-right-mid {
+	right: 14px;
+	top: calc(14px + 100% / 9 + 10px);
+	width: calc(100% * 2 / 7 - 14px);
+	height: calc(100% * 4 / 9 - 8px);
+}
+
+.mini-right-bottom {
+	right: 14px;
+	bottom: 14px;
+	width: calc(100% * 2 / 7 - 14px);
+	height: calc(100% * 4 / 9 - 8px);
+}
+
+.mini-overflow {
+	left: 14px;
+	top: calc(14px + 42% + 1px);
+	width: calc(100% * 4 / 7);
+	height: 32%;
+}
+
+.wall-card-right {
+	width: min(20vw, 320px);
+	min-height: 320px;
+	justify-self: end;
+}
+
+.right-zone {
+	display: grid;
+	gap: 18px;
+}
+
+.window-card {
+	width: 100%;
 	border-radius: 10px;
+	border: 1px solid #729fce;
+	background: #fdfefe;
+	box-shadow: 0 10px 22px rgba(72, 106, 152, 0.16);
+	overflow: hidden;
 }
 
-.iv-drop {
-	width: 22px;
-	height: 48px;
-	border: 1px solid #c7e9f0;
-	border-radius: 0 0 11px 11px;
-	position: relative;
+.window-title {
+	padding: 8px 10px;
+	font-size: 13px;
+	background: linear-gradient(180deg, #dbeaff 0%, #b7d0f3 100%);
+	border-bottom: 1px solid #88acd6;
 }
-.iv-drop::after {
+
+.window-card p {
+	margin: 0;
+	padding: 14px 12px;
+	font-size: 13px;
+}
+
+.character-zone {
+	position: relative;
+	min-height: 360px;
+}
+
+.character-placeholder {
+	height: 360px;
+	border: 2px dashed #8fb1d6;
+	border-radius: 20px;
+	background: repeating-linear-gradient(135deg, #edf5ff 0 10px, #dfebfa 10px 20px);
+	display: grid;
+	place-items: center;
+	font-size: 14px;
+	color: #5e7c9b;
+}
+
+.bubble-card,
+.overlay-card {
+	position: absolute;
+	border: 1px solid #adc4e0;
+	background: #fff;
+	box-shadow: 0 8px 20px rgba(89, 124, 170, 0.16);
+}
+
+.bubble-card {
+	top: 18px;
+	left: -12px;
+	padding: 8px 12px;
+	border-radius: 16px;
+}
+
+.bubble-card::after {
 	content: "";
 	position: absolute;
-	left: 7px;
-	top: 8px;
-	width: 6px;
-	height: 10px;
-	border-radius: 999px;
-	background: #c7e9f0;
-	animation: drop 3s infinite;
-}
-@keyframes drop {
-	0% { transform: translateY(0); opacity: 0; }
-	20% { opacity: 1; }
-	100% { transform: translateY(26px); opacity: 0; }
+	left: 18px;
+	bottom: -10px;
+	width: 14px;
+	height: 14px;
+	background: #fff;
+	border-right: 1px solid #adc4e0;
+	border-bottom: 1px solid #adc4e0;
+	transform: rotate(45deg);
 }
 
-.fade-stagger {
-	opacity: 0;
-	animation: cardIn 0.5s ease forwards;
+.overlay-top {
+	top: 150px;
+	right: -10px;
+	width: 58%;
+	padding: 12px;
+	border-radius: 14px;
 }
-@keyframes cardIn {
-	from { opacity: 0; transform: translateY(10px); }
-	to { opacity: 1; transform: translateY(0); }
+
+.overlay-bottom {
+	top: 220px;
+	left: -8px;
+	width: 56%;
+	padding: 12px;
+	border-radius: 14px;
+}
+
+.desktop-gallery {
+	position: relative;
+	z-index: 4;
+	margin-top: 24px;
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 14px;
+}
+
+.desk-item {
+	border: 1px solid #9ebde0;
+	background: #fafdff;
+	border-radius: 12px;
+	min-height: 110px;
+	display: grid;
+	place-items: center;
+	box-shadow: 0 6px 12px rgba(43, 82, 130, 0.14);
+	transition: transform 0.24s ease, box-shadow 0.24s ease;
+}
+
+.desk-item:hover {
+	transform: translateY(-8px);
+	box-shadow: 0 16px 24px rgba(43, 82, 130, 0.22);
+}
+
+@media (max-width: 1100px) {
+	.scene-layout,
+	.wall-zone {
+		grid-template-columns: 1fr;
+	}
+
+	.wall-card-right {
+		width: 100%;
+		justify-self: stretch;
+	}
+
+	.right-zone {
+		max-width: 460px;
+	}
+
+	.desktop-gallery {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 760px) {
+	.scene-home {
+		padding: 14px 12px 20vh;
+	}
+
+	.desktop-gallery {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.scene-corner {
+		width: 35vw;
+		height: 35vw;
+	}
 }

--- a/src/styles/layout/base.css
+++ b/src/styles/layout/base.css
@@ -35,6 +35,12 @@ main#main {
 	padding-bottom: 32px;
 }
 
+body.site-shell:has(.scene-home) main#main {
+	width: 100%;
+	margin-top: 112px;
+	padding-inline: 0;
+}
+
 h1, h2, h3, h4, h5, h6 { font-weight: 500; line-height: 1.4; color: var(--text-main); }
 .small-muted { font-weight: 300; color: var(--text-muted); }
 
@@ -81,9 +87,35 @@ a { color: var(--text-main); text-decoration: none; }
 	gap: 24px;
 	max-width: 1120px;
 	margin: 0 auto;
+	position: relative;
+	padding-bottom: 12px;
+}
+
+.site-nav-shell::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 8px;
+	background:
+		radial-gradient(circle at 8px -2px, transparent 8px, #92b4db 8.5px, #92b4db 10px, transparent 10.5px)
+		0 0 / 16px 8px repeat-x;
+	opacity: 0.95;
 }
 
 .site-logo { font-weight: 500; }
+.site-home-title {
+	margin: 0;
+	position: absolute;
+	left: 50%;
+	transform: translateX(-50%);
+	font-size: clamp(24px, 3.4vw, 36px);
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	color: #4f6f96;
+	text-shadow: 0 1px 0 rgba(255,255,255,.7);
+}
 .site-nav-links { display: flex; flex-wrap: wrap; gap: 24px; }
 .site-nav-link { position: relative; color: var(--text-main); }
 .site-nav-link:hover { color: var(--primary-300); }
@@ -125,4 +157,5 @@ a { color: var(--text-main); text-decoration: none; }
 	main#main { width: calc(100% - 1.2rem); margin-top: 92px; }
 	#main-header { padding: 14px 12px; }
 	.site-nav-links { gap: 16px; }
+	.site-home-title { font-size: clamp(20px, 6vw, 28px); }
 }


### PR DESCRIPTION
### Motivation
- Implement a layered, scene-like homepage to match the described “sticker/landscape” design: striped wallpaper, bottom desktop band (~1/10 height), bottom-right folded-corner triangle (~1/5 width), a Windows-style window under the nav, a character area with overlapping cards, and five desktop image slots with hover lift.
- Make the header behave differently on the home page by replacing nav links with a centered site title and add a decorative wavy bottom border to the nav for the intended visual effect.

### Description
- Added a new scene layout and placeholders in `src/pages/index.astro` including `.scene-home`, `.scene-desktop`, `.scene-corner`, the wall-zone (two large wall cards with nested mini-cards), the right-zone window and character area, and five desktop gallery slots.
- Updated header logic in `src/components/layout/Header.astro` to detect home (`isHome`) and render a centered `h1.site-home-title` on `/` while preserving existing nav links on other pages.
- Implemented CSS for the composition in `src/styles/components/homepage.css` adding positioning, sizing (fractional widths/heights per spec), mini-card stacking/overflow, bubble/overlay cards, and the desktop card hover lift animation.
- Modified `src/styles/layout/base.css` to add home-specific full-width `main#main` behavior and a wavy decorative `::after` rule on `.site-nav-shell`, plus styles for `.site-home-title`.

### Testing
- Ran the site build with `npm run build`, which completed successfully and produced the static output without errors.
- The build produced static pages and ancillary artifacts (sitemap/robots and Pagefind indexing) as part of the normal build pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e8f805f0832c879ba5834826c6ad)