### PR TITLE
feat: make homepage cards fit single desktop viewport

### DIFF
--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -1,8 +1,12 @@
 .scene-home {
 	position: relative;
-	min-height: calc(100vh - 150px);
-	padding: 24px 24px 18vh;
+	height: 100%;
+	min-height: 0;
+	padding: 18px 24px 10px;
 	overflow: hidden;
+	display: grid;
+	grid-template-rows: minmax(0, 1fr) auto;
+	gap: 14px;
 }
 
 .scene-desktop {
@@ -39,15 +43,17 @@
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) minmax(220px, 20vw);
 	gap: 24px;
-	align-items: start;
+	align-items: stretch;
+	min-height: 0;
 }
 
 .wall-zone {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) minmax(220px, 20vw);
 	gap: 20px;
-	align-items: start;
+	align-items: stretch;
 	margin-right: 8px;
+	min-height: 0;
 }
 
 .wall-card {
@@ -57,7 +63,7 @@
 	background: rgba(255, 255, 255, 0.83);
 	box-shadow: 0 14px 36px rgba(72, 106, 152, 0.14);
 	padding: 20px;
-	min-height: 320px;
+	min-height: 260px;
 }
 
 .wall-card-left {
@@ -111,7 +117,7 @@
 
 .wall-card-right {
 	width: min(20vw, 320px);
-	min-height: 320px;
+	min-height: 260px;
 	justify-self: end;
 }
 
@@ -144,11 +150,11 @@
 
 .character-zone {
 	position: relative;
-	min-height: 360px;
+	min-height: 280px;
 }
 
 .character-placeholder {
-	height: 360px;
+	height: 280px;
 	border: 2px dashed #8fb1d6;
 	border-radius: 20px;
 	background: repeating-linear-gradient(135deg, #edf5ff 0 10px, #dfebfa 10px 20px);
@@ -187,7 +193,7 @@
 }
 
 .overlay-top {
-	top: 150px;
+	top: 120px;
 	right: -10px;
 	width: 58%;
 	padding: 12px;
@@ -195,7 +201,7 @@
 }
 
 .overlay-bottom {
-	top: 220px;
+	top: 178px;
 	left: -8px;
 	width: 56%;
 	padding: 12px;
@@ -205,7 +211,6 @@
 .desktop-gallery {
 	position: relative;
 	z-index: 4;
-	margin-top: 24px;
 	display: grid;
 	grid-template-columns: repeat(5, minmax(0, 1fr));
 	gap: 14px;
@@ -215,7 +220,7 @@
 	border: 1px solid #9ebde0;
 	background: #fafdff;
 	border-radius: 12px;
-	min-height: 110px;
+	min-height: 84px;
 	display: grid;
 	place-items: center;
 	box-shadow: 0 6px 12px rgba(43, 82, 130, 0.14);
@@ -228,6 +233,12 @@
 }
 
 @media (max-width: 1100px) {
+	.scene-home {
+		height: auto;
+		min-height: calc(100vh - 112px);
+		padding-bottom: 20vh;
+	}
+
 	.scene-layout,
 	.wall-zone {
 		grid-template-columns: 1fr;

--- a/src/styles/layout/base.css
+++ b/src/styles/layout/base.css
@@ -39,6 +39,16 @@ body.site-shell:has(.scene-home) main#main {
 	width: 100%;
 	margin-top: 112px;
 	padding-inline: 0;
+	padding-bottom: 0;
+	height: calc(100vh - 112px);
+}
+
+body.site-shell:has(.scene-home) {
+	overflow: hidden;
+}
+
+body.site-shell:has(.scene-home) .site-footer {
+	display: none;
 }
 
 h1, h2, h3, h4, h5, h6 { font-weight: 500; line-height: 1.4; color: var(--text-main); }
@@ -155,6 +165,17 @@ a { color: var(--text-main); text-decoration: none; }
 
 @media (max-width: 720px) {
 	main#main { width: calc(100% - 1.2rem); margin-top: 92px; }
+	body.site-shell:has(.scene-home) {
+		overflow: auto;
+	}
+
+	body.site-shell:has(.scene-home) main#main {
+		height: auto;
+	}
+
+	body.site-shell:has(.scene-home) .site-footer {
+		display: block;
+	}
 	#main-header { padding: 14px 12px; }
 	.site-nav-links { gap: 16px; }
 	.site-home-title { font-size: clamp(20px, 6vw, 28px); }


### PR DESCRIPTION
### Motivation
- Reduce homepage vertical space so all cards fit within a single desktop viewport without requiring page scroll.  
- Preserve mobile behavior by restoring normal scrolling and footer on small screens.

### Description
- Convert `.scene-home` into a fixed viewport-height two-row grid and remove extra vertical padding to keep the page within one screen (`src/styles/components/homepage.css`).
- Reduce heights of main blocks (`.wall-card`, `.wall-card-right`, `.character-zone`, `.character-placeholder`, `.desk-item`) and adjust overlay positions so the composition fits a single desktop screen (`src/styles/components/homepage.css`).
- Constrain the site shell `main#main` to `calc(100vh - 112px)`, hide the page footer and disable body scroll when `.scene-home` is present to prevent scrolling on desktop, and restore scrolling/footer behavior under `@media (max-width:720px)` for mobile (`src/styles/layout/base.css`).

### Testing
- Ran `npm run build` and the build completed successfully (static pages generated and `pagefind` indexing ran).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8ebbfe540832c95fc793b7b8d7fbe)