### PR TITLE
Refactor site into a minimal classic blog layout

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -4,29 +4,24 @@ import { menuLinks } from "@/site.config";
 const navItems = menuLinks.flatMap((link) =>
 	link.children?.length ? link.children : [link],
 ).filter((item) => item.path);
-
-const isHome = Astro.url.pathname === "/";
 ---
 
 <header id="main-header">
 	<nav aria-label="Main menu" class="site-nav-shell">
 		<a class="site-logo" href="/">Eucaly's Blog</a>
-		{isHome ? (
-			<h1 class="site-home-title">Eucaly's Blog</h1>
-		) : (
-			<div class="site-nav-links">
-				{navItems.map((link) => (
-					<a
-						aria-current={Astro.url.pathname === link.path ? "page" : false}
-						class="site-nav-link"
-						href={link.path}
-						target={link.external ? "_blank" : undefined}
-						rel={link.external ? "noreferrer" : undefined}
-					>
-						{link.title}
-					</a>
-				))}
-			</div>
-		)}
+		<div class="site-nav-links">
+			<a aria-current={Astro.url.pathname === "/" ? "page" : false} class="site-nav-link" href="/">Home</a>
+			{navItems.map((link) => (
+				<a
+					aria-current={Astro.url.pathname === link.path ? "page" : false}
+					class="site-nav-link"
+					href={link.path}
+					target={link.external ? "_blank" : undefined}
+					rel={link.external ? "noreferrer" : undefined}
+				>
+					{link.title}
+				</a>
+			))}
+		</div>
 	</nav>
 </header>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -13,31 +13,8 @@ const { meta: { articleDate, description = siteConfig.description, ogImage, titl
 <html lang={siteConfig.lang}>
 	<head><BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} /></head>
 	<body class="site-shell">
-		<div aria-hidden="true" class="initial-loader" id="initial-loader">
-			<div class="initial-loader__icon">🪽</div>
-		</div>
 		<Header />
 		<main class="page-fade" id="main"><slot /></main>
 		<Footer />
 	</body>
 </html>
-
-<script is:inline>
-	const initLayoutEffects = () => {
-		const loader = document.getElementById("initial-loader");
-		if (loader && !sessionStorage.getItem("site-loader-seen")) {
-			sessionStorage.setItem("site-loader-seen", "1");
-			setTimeout(() => loader.classList.add("initial-loader--hidden"), 2000);
-		} else {
-			loader?.classList.add("initial-loader--hidden");
-		}
-
-		const nav = document.getElementById("main-header");
-		const toggleNav = () => nav?.classList.toggle("is-scrolled", window.scrollY > 8);
-		toggleNav();
-		window.addEventListener("scroll", toggleNav, { passive: true });
-	};
-
-	document.addEventListener("astro:page-load", initLayoutEffects);
-	initLayoutEffects();
-</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,45 +1,32 @@
 ---
 import PageLayout from "@/layouts/Base.astro";
+
+const contacts = [
+	{ label: "邮箱", value: "isntbunny@outlook.com", href: "mailto:isntbunny@outlook.com" },
+	{ label: "GitHub", value: "github.com/isntbunny", href: "https://github.com/isntbunny" },
+];
 ---
 
-<PageLayout meta={{ title: "Home" }}>
-	<section class="scene-home">
-		<div aria-hidden="true" class="scene-desktop"></div>
-		<div aria-hidden="true" class="scene-corner"></div>
+<PageLayout meta={{ title: "Home", description: "个人博客主页" }}>
+	<section class="home-simple site-card">
+		<h1>你好，我是 Eucaly。</h1>
+		<p>
+			这里是我的个人博客，主要记录日常想法、阅读心得和一些学习笔记。
+			如果你想联系我，可以通过下面的方式找到我。
+		</p>
+	</section>
 
-		<div class="scene-layout">
-			<section class="wall-zone">
-				<div class="wall-card wall-card-left">
-					<div class="mini-card mini-left">左侧小卡片（5/7）</div>
-					<div class="mini-card mini-right-top">右上小卡片（1/9）</div>
-					<div class="mini-card mini-right-mid">右中小卡片（4/9）</div>
-					<div class="mini-card mini-right-bottom">右下小卡片（4/9）</div>
-					<div class="mini-card mini-overflow">溢出小卡片（4/7）</div>
-				</div>
-				<div class="wall-card wall-card-right">右侧大卡片占位（宽约 1/5 屏幕）</div>
-			</section>
-
-			<aside class="right-zone">
-				<article class="window-card">
-					<header class="window-title">Windows 卡片</header>
-					<p>这里是导航栏下方、三角形上方的窗口样式区域。</p>
-				</article>
-
-				<div class="character-zone">
-					<div class="character-placeholder">人物图片占位符</div>
-					<div class="bubble-card">漫画气泡卡片（头部）</div>
-					<div class="overlay-card overlay-top">交错卡片 A（身体）</div>
-					<div class="overlay-card overlay-bottom">交错卡片 B（身体）</div>
-				</div>
-			</aside>
-		</div>
-
-		<section class="desktop-gallery" aria-label="桌面图片位置">
-			<div class="desk-item">图片位 1</div>
-			<div class="desk-item">图片位 2</div>
-			<div class="desk-item">图片位 3</div>
-			<div class="desk-item">图片位 4</div>
-			<div class="desk-item">图片位 5</div>
-		</section>
+	<section class="home-simple site-card">
+		<h2>联系方式</h2>
+		<ul class="home-contact-list">
+			{contacts.map((item) => (
+				<li>
+					<span>{item.label}</span>
+					<a href={item.href} rel="noreferrer" target={item.href.startsWith("http") ? "_blank" : undefined}>
+						{item.value}
+					</a>
+				</li>
+			))}
+		</ul>
 	</section>
 </PageLayout>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -42,17 +42,10 @@ export const siteConfig: SiteConfig & { backgroundImage: string; bangumiUsername
 
 // Used to generate links in both the Header & Footer.
 export const menuLinks: MenuLink[] = [
+	{ path: "/posts/", title: "Posts" },
 	{ path: "/archive/", title: "Archive" },
-	{ path: "/memos/", title: "Memos" },
-	{ path: "/gallery/", title: "Gallery" },
-	{ path: "/guestbook/", title: "Guestbook" },
-	{
-		title: "About",
-		children: [
-			{ path: "/about/", title: "Readme.md" },
-			{ path: "/bangumi/", title: "Bangumi" },
-		],
-	},
+	{ path: "/tags/", title: "Tags" },
+	{ path: "/about/", title: "About" },
 ];
 
 // https://expressive-code.com/reference/configuration/

--- a/src/styles/components/homepage.css
+++ b/src/styles/components/homepage.css
@@ -1,274 +1,42 @@
-.scene-home {
-	position: relative;
-	height: 100%;
-	min-height: 0;
-	padding: 18px 24px 10px;
-	overflow: hidden;
-	display: grid;
-	grid-template-rows: minmax(0, 1fr) auto;
-	gap: 14px;
+.home-simple {
+	max-width: 720px;
+	margin: 0 auto 20px;
 }
 
-.scene-desktop {
-	position: absolute;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	height: 10vh;
-	background: #a8c6e8;
-	border-top: 2px solid rgba(255, 255, 255, 0.65);
-	z-index: 1;
+.home-simple h1,
+.home-simple h2 {
+	margin: 0 0 12px;
 }
 
-.scene-corner {
-	position: absolute;
-	right: 0;
-	bottom: 10vh;
-	width: 20vw;
-	height: 20vw;
-	max-width: 320px;
-	max-height: 320px;
-	min-width: 140px;
-	min-height: 140px;
-	background: linear-gradient(135deg, #f9fbff 0%, #dfebfa 100%);
-	clip-path: polygon(100% 0, 0 100%, 100% 100%);
-	border-left: 1px solid #b9cde8;
-	border-top: 1px solid #d9e5f6;
-	z-index: 2;
-}
-
-.scene-layout {
-	position: relative;
-	z-index: 3;
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) minmax(220px, 20vw);
-	gap: 24px;
-	align-items: stretch;
-	min-height: 0;
-}
-
-.wall-zone {
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) minmax(220px, 20vw);
-	gap: 20px;
-	align-items: stretch;
-	margin-right: 8px;
-	min-height: 0;
-}
-
-.wall-card {
-	position: relative;
-	border-radius: 16px;
-	border: 1px solid #9dbfe4;
-	background: rgba(255, 255, 255, 0.83);
-	box-shadow: 0 14px 36px rgba(72, 106, 152, 0.14);
-	padding: 20px;
-	min-height: 260px;
-}
-
-.wall-card-left {
-	isolation: isolate;
-}
-
-.mini-card {
-	position: absolute;
-	border: 1px solid #b8cde8;
-	border-radius: 12px;
-	background: #f6faff;
-	box-shadow: 0 8px 20px rgba(89, 124, 170, 0.12);
-	padding: 10px;
-	font-size: 13px;
-}
-
-.mini-left {
-	left: 14px;
-	top: 14px;
-	width: calc(100% * 5 / 7);
-	height: 42%;
-}
-
-.mini-right-top {
-	right: 14px;
-	top: 14px;
-	width: calc(100% * 2 / 7 - 14px);
-	height: calc(100% / 9);
-}
-
-.mini-right-mid {
-	right: 14px;
-	top: calc(14px + 100% / 9 + 10px);
-	width: calc(100% * 2 / 7 - 14px);
-	height: calc(100% * 4 / 9 - 8px);
-}
-
-.mini-right-bottom {
-	right: 14px;
-	bottom: 14px;
-	width: calc(100% * 2 / 7 - 14px);
-	height: calc(100% * 4 / 9 - 8px);
-}
-
-.mini-overflow {
-	left: 14px;
-	top: calc(14px + 42% + 1px);
-	width: calc(100% * 4 / 7);
-	height: 32%;
-}
-
-.wall-card-right {
-	width: min(20vw, 320px);
-	min-height: 260px;
-	justify-self: end;
-}
-
-.right-zone {
-	display: grid;
-	gap: 18px;
-}
-
-.window-card {
-	width: 100%;
-	border-radius: 10px;
-	border: 1px solid #729fce;
-	background: #fdfefe;
-	box-shadow: 0 10px 22px rgba(72, 106, 152, 0.16);
-	overflow: hidden;
-}
-
-.window-title {
-	padding: 8px 10px;
-	font-size: 13px;
-	background: linear-gradient(180deg, #dbeaff 0%, #b7d0f3 100%);
-	border-bottom: 1px solid #88acd6;
-}
-
-.window-card p {
+.home-simple p {
 	margin: 0;
-	padding: 14px 12px;
-	font-size: 13px;
+	color: var(--text-main);
 }
 
-.character-zone {
-	position: relative;
-	min-height: 280px;
-}
-
-.character-placeholder {
-	height: 280px;
-	border: 2px dashed #8fb1d6;
-	border-radius: 20px;
-	background: repeating-linear-gradient(135deg, #edf5ff 0 10px, #dfebfa 10px 20px);
+.home-contact-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
 	display: grid;
-	place-items: center;
-	font-size: 14px;
-	color: #5e7c9b;
+	gap: 10px;
 }
 
-.bubble-card,
-.overlay-card {
-	position: absolute;
-	border: 1px solid #adc4e0;
-	background: #fff;
-	box-shadow: 0 8px 20px rgba(89, 124, 170, 0.16);
+.home-contact-list li {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 10px 12px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	background: rgba(255, 255, 255, 0.75);
 }
 
-.bubble-card {
-	top: 18px;
-	left: -12px;
-	padding: 8px 12px;
-	border-radius: 16px;
+.home-contact-list a {
+	color: var(--text-main);
+	font-weight: 500;
 }
 
-.bubble-card::after {
-	content: "";
-	position: absolute;
-	left: 18px;
-	bottom: -10px;
-	width: 14px;
-	height: 14px;
-	background: #fff;
-	border-right: 1px solid #adc4e0;
-	border-bottom: 1px solid #adc4e0;
-	transform: rotate(45deg);
-}
-
-.overlay-top {
-	top: 120px;
-	right: -10px;
-	width: 58%;
-	padding: 12px;
-	border-radius: 14px;
-}
-
-.overlay-bottom {
-	top: 178px;
-	left: -8px;
-	width: 56%;
-	padding: 12px;
-	border-radius: 14px;
-}
-
-.desktop-gallery {
-	position: relative;
-	z-index: 4;
-	display: grid;
-	grid-template-columns: repeat(5, minmax(0, 1fr));
-	gap: 14px;
-}
-
-.desk-item {
-	border: 1px solid #9ebde0;
-	background: #fafdff;
-	border-radius: 12px;
-	min-height: 84px;
-	display: grid;
-	place-items: center;
-	box-shadow: 0 6px 12px rgba(43, 82, 130, 0.14);
-	transition: transform 0.24s ease, box-shadow 0.24s ease;
-}
-
-.desk-item:hover {
-	transform: translateY(-8px);
-	box-shadow: 0 16px 24px rgba(43, 82, 130, 0.22);
-}
-
-@media (max-width: 1100px) {
-	.scene-home {
-		height: auto;
-		min-height: calc(100vh - 112px);
-		padding-bottom: 20vh;
-	}
-
-	.scene-layout,
-	.wall-zone {
-		grid-template-columns: 1fr;
-	}
-
-	.wall-card-right {
-		width: 100%;
-		justify-self: stretch;
-	}
-
-	.right-zone {
-		max-width: 460px;
-	}
-
-	.desktop-gallery {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
-}
-
-@media (max-width: 760px) {
-	.scene-home {
-		padding: 14px 12px 20vh;
-	}
-
-	.desktop-gallery {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-
-	.scene-corner {
-		width: 35vw;
-		height: 35vw;
-	}
+.home-contact-list a:hover {
+	color: var(--primary-300);
 }

--- a/src/styles/layout/base.css
+++ b/src/styles/layout/base.css
@@ -30,28 +30,12 @@ body.site-shell {
 }
 
 main#main {
-	width: min(1120px, calc(100% - 2rem));
-	margin: 108px auto 0;
-	padding-bottom: 32px;
+	width: min(920px, calc(100% - 2rem));
+	margin: 90px auto 0;
+	padding-bottom: 40px;
 }
 
-body.site-shell:has(.scene-home) main#main {
-	width: 100%;
-	margin-top: 112px;
-	padding-inline: 0;
-	padding-bottom: 0;
-	height: calc(100vh - 112px);
-}
-
-body.site-shell:has(.scene-home) {
-	overflow: hidden;
-}
-
-body.site-shell:has(.scene-home) .site-footer {
-	display: none;
-}
-
-h1, h2, h3, h4, h5, h6 { font-weight: 500; line-height: 1.4; color: var(--text-main); }
+h1, h2, h3, h4, h5, h6 { font-weight: 600; line-height: 1.4; color: var(--text-main); }
 .small-muted { font-weight: 300; color: var(--text-muted); }
 
 a { color: var(--text-main); text-decoration: none; }
@@ -61,12 +45,8 @@ a { color: var(--text-main); text-decoration: none; }
 	background: var(--white);
 	border: 1px solid var(--border);
 	box-shadow: var(--card-shadow);
-	backdrop-filter: blur(6px);
 	padding: 20px;
-	transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
-
-.site-card:hover { transform: translateY(-2px); box-shadow: var(--hover-shadow); }
 
 .site-chip {
 	display: inline-flex;
@@ -80,53 +60,23 @@ a { color: var(--text-main); text-decoration: none; }
 	position: fixed;
 	inset: 0 0 auto 0;
 	z-index: 120;
-	padding: 16px 24px;
-	transition: background-color 0.3s ease, backdrop-filter 0.3s ease, box-shadow 0.3s ease;
-}
-
-#main-header.is-scrolled {
+	padding: 14px 24px;
 	background: rgba(255, 255, 255, 0.8);
 	backdrop-filter: blur(8px);
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.02);
+	border-bottom: 1px solid rgba(226, 232, 240, 0.85);
 }
 
 .site-nav-shell {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 24px;
-	max-width: 1120px;
+	gap: 20px;
+	max-width: 920px;
 	margin: 0 auto;
-	position: relative;
-	padding-bottom: 12px;
 }
 
-.site-nav-shell::after {
-	content: "";
-	position: absolute;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	height: 8px;
-	background:
-		radial-gradient(circle at 8px -2px, transparent 8px, #92b4db 8.5px, #92b4db 10px, transparent 10.5px)
-		0 0 / 16px 8px repeat-x;
-	opacity: 0.95;
-}
-
-.site-logo { font-weight: 500; }
-.site-home-title {
-	margin: 0;
-	position: absolute;
-	left: 50%;
-	transform: translateX(-50%);
-	font-size: clamp(24px, 3.4vw, 36px);
-	font-weight: 600;
-	letter-spacing: 0.06em;
-	color: #4f6f96;
-	text-shadow: 0 1px 0 rgba(255,255,255,.7);
-}
-.site-nav-links { display: flex; flex-wrap: wrap; gap: 24px; }
+.site-logo { font-weight: 600; }
+.site-nav-links { display: flex; flex-wrap: wrap; gap: 16px; }
 .site-nav-link { position: relative; color: var(--text-main); }
 .site-nav-link:hover { color: var(--primary-300); }
 .site-nav-link[aria-current="page"]::after {
@@ -134,49 +84,25 @@ a { color: var(--text-main); text-decoration: none; }
 	position: absolute;
 	left: 0;
 	right: 0;
-	bottom: -8px;
+	bottom: -6px;
 	height: 2px;
 	background: var(--primary-300);
 }
 
 .site-footer {
-	padding: 40px 0;
+	padding: 28px 0;
 	text-align: center;
 	font-size: 14px;
 	color: var(--text-muted);
 	border-top: 1px solid var(--border);
 }
 
-.page-fade { animation: pageFade 0.3s ease both; }
+.page-fade { animation: pageFade 0.25s ease both; }
 @keyframes pageFade { from { opacity: 0; } to { opacity: 1; } }
 
-.initial-loader {
-	position: fixed;
-	inset: 0;
-	z-index: 400;
-	display: grid;
-	place-items: center;
-	background: rgba(240, 247, 250, 0.96);
-	transition: opacity 0.4s ease;
-}
-.initial-loader__icon { font-size: 48px; animation: spin 2s linear; }
-.initial-loader--hidden { opacity: 0; pointer-events: none; }
-@keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }
-
 @media (max-width: 720px) {
-	main#main { width: calc(100% - 1.2rem); margin-top: 92px; }
-	body.site-shell:has(.scene-home) {
-		overflow: auto;
-	}
-
-	body.site-shell:has(.scene-home) main#main {
-		height: auto;
-	}
-
-	body.site-shell:has(.scene-home) .site-footer {
-		display: block;
-	}
-	#main-header { padding: 14px 12px; }
-	.site-nav-links { gap: 16px; }
-	.site-home-title { font-size: clamp(20px, 6vw, 28px); }
+	main#main { width: calc(100% - 1.2rem); margin-top: 84px; }
+	#main-header { padding: 12px; }
+	.site-nav-shell { flex-direction: column; align-items: flex-start; gap: 8px; }
+	.site-nav-links { gap: 12px; }
 }


### PR DESCRIPTION
### Motivation
- Convert the current decorative homepage into a normal, minimal blog homepage that shows only a short intro and contact methods while keeping the existing color palette. 
- Simplify layout and navigation to behave like a conventional blog (stable header, clear menu entries) and remove heavy decorative scripts and overlays. 

### Description
- Replaced the complex visual home scene with a simple introduction and contact card in `src/pages/index.astro` and added minimal homepage styles in `src/styles/components/homepage.css`. 
- Updated the header to always show a conventional menu with a `Home` entry in `src/components/layout/Header.astro`. 
- Simplified site menu entries in `src/site.config.ts` to `Posts`, `Archive`, `Tags`, and `About`. 
- Removed the initial loading overlay and its layout JS and trimmed layout CSS in `src/layouts/Base.astro` and `src/styles/layout/base.css` to streamline the global layout while preserving the theme color variables. 

### Testing
- Ran `npm run build` which completed successfully and produced the static site (Astro build completed). 
- Postbuild `pagefind` ran during `npm run build` and completed indexing as part of the build pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d348b60bb4832c8814e460d5ae0f63)