### PR TITLE
Unify theme to homepage palette, fix fixed header spacing, add smooth animations

### DIFF
--- a/src/components/GithubCommits.astro
+++ b/src/components/GithubCommits.astro
@@ -49,7 +49,7 @@ const sortedDates = Object.keys(groupedCommits).sort((a, b) => {
 });
 ---
 
-{errorMsg && <p style="color: #888; font-size: 0.9rem;">⚠️ {errorMsg}</p>}
+{errorMsg && <p style="color: var(--ink-faint); font-size: 0.9rem;">⚠️ {errorMsg}</p>}
 
 {commits.length > 0 && (
   <div class="commit-list">
@@ -96,20 +96,20 @@ const sortedDates = Object.keys(groupedCommits).sort((a, b) => {
         justify-content: space-between;
         align-items: center;
         padding: 0.4rem 0;
-        border-bottom: 2px solid #e1e4e8;
+        border-bottom: 2px solid var(--angel-blue-light);
         margin-bottom: 0.5rem;
       }
       
       .date-label {
         font-weight: 600;
         font-size: 1rem;
-        color: #24292e;
+        color: var(--angel-text);
       }
       
       .commit-count {
         font-size: 0.8rem;
-        color: #586069;
-        background: #f0f0f0;
+        color: var(--ink-soft);
+        background: var(--angel-blue-pale);
         padding: 0.1rem 0.7rem;
         border-radius: 12px;
       }
@@ -125,17 +125,17 @@ const sortedDates = Object.keys(groupedCommits).sort((a, b) => {
         display: inline;
         font-weight: 500;
         min-width: 150px;
-        color: #24292e;
+        color: var(--angel-text);
       }
 
       .commit-list p::after{
           content: ' ';
-          color: #c0c0c0;
+          color: var(--angel-gray);
       }
       
       .meta {
         font-size: 0.8rem;
-        color: #586069;
+        color: var(--ink-soft);
         white-space: nowrap;
         display: flex;
         align-items: center;

--- a/src/components/blog/TOC.astro
+++ b/src/components/blog/TOC.astro
@@ -47,7 +47,7 @@ const toc = generateToc(headings);
     cursor: pointer;
     font-size: 1.125rem;  /* text-lg */
     font-weight: 500;
-    color: var(--accent-color, #3b82f6);
+    color: var(--accent-color, var(--angel-blue));
   }
 
   /* 注意：浏览器默认的 summary 三角标记比较难直接改颜色，

--- a/src/pages/nav/index.astro
+++ b/src/pages/nav/index.astro
@@ -90,7 +90,7 @@ try {
     gap: 1rem;
   }
   .card {
-    background: #ffffff;
+    background: var(--card-bg);
     padding: 1rem;
     border-radius: 12px;
     text-decoration: none;
@@ -99,6 +99,6 @@ try {
   }
   .card:hover {transform: translateY(-2px); }
   .card strong { display: block; font-size: 1.1rem; margin-bottom: 0.25rem; }
-  .url { font-size: 0.75rem; color: #89b4fa; word-break: break-all; }
-  .desc { font-size: 0.8rem; color: #a6adc8; display: block; margin-top: 0.5rem; }
+  .url { font-size: 0.75rem; color: var(--ink-faint); word-break: break-all; }
+  .desc { font-size: 0.8rem; color: var(--ink-soft); display: block; margin-top: 0.5rem; }
 </style>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2,18 +2,20 @@
 /*这里存放的是布局样式*/
 /*******************/
 
-
+html {
+	scroll-padding-top: calc(var(--header-height) + 1rem);
+}
 
 h1::after, h1::before {
     content: ""; 
-	color: #ffffff00;                    /* 伪元素不需要文字内容 */
-    display: block;                  /* 块级元素，让图片另起一行 */
-    width: auto;                     /* 图片显示宽度 */
-    height: 0.6em;                   /* 图片显示高度 */
-    margin: 3px;                /* 与标题文字的间距 */
+	color: transparent;
+    display: block;
+    width: auto;
+    height: 0.6em;
+    margin: 3px;
     background-image: url("");
-    background-size: contain;        /* 按比例缩放以适应宽或高 */
-    background-repeat:repeat-x;
+    background-size: contain;
+    background-repeat: repeat-x;
     background-position: center;
 }
 
@@ -22,16 +24,21 @@ body.site-shell {
 	font-weight: 400;
 	line-height: 1.5;
 	color: var(--text-main);
-	animation: pageFade 0.55s ease both
+	animation: pageFade 0.55s ease both;
 }
-
 
 body {
 	background-size: 3em 3em;
-	background-color: #eff6ff;
+	background-color: var(--paper-bg);
+	background-image:
+		radial-gradient(circle at 1px 1px, rgba(184, 212, 232, 0.22) 1px, transparent 0);
 	opacity: 1;
-	padding: 0px 15%;
-	color: #4d657a;
+	padding: var(--header-height) 15% 0;
+	color: var(--angel-text);
+}
+
+main#main {
+	padding-top: 1rem;
 }
 
 .small-muted {
@@ -39,23 +46,19 @@ body {
 	color: var(--text-muted);
 }
 
-
-/* 卡片 */
-
 .sitecard {
-    background: rgb(255 255 255 / 0.73);
-    backdrop-filter: blur(13px);
-    -webkit-backdrop-filter: blur(13px);
-    border-radius: 25px;
-    border: 1px solid rgb(184 234 255 / 0);
-    box-shadow: rgb(77 143 214 / 0.34) 0px 8px 32px 0px;  
+    background: var(--card-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-radius: 24px;
+    border: 1px solid var(--glass-border);
+    box-shadow: var(--card-shadow);
     position: relative;
     padding: 2rem;
     margin-bottom: 2rem;
     opacity: 0;
 	transform: translateY(30px);
-	transition: opacity 0.8s ease-out, transform 0.8s ease-out;
-
+	transition: opacity 0.8s ease-out, transform 0.8s ease-out, box-shadow 0.25s ease, background 0.25s ease;
 }
 
 .sitecard.visible {
@@ -63,16 +66,22 @@ body {
 	transform: translateY(0);
 }
 
-/* 标题导航栏 */
+.sitecard:hover {
+	background: var(--card-bg-hover);
+	box-shadow: var(--hover-shadow);
+}
 
 #main-header { 
 	position: fixed;
 	inset: 0 0 auto 0;
 	z-index: 100;
-	padding: 5px 25px;
-	background: rgba(255, 255, 255, 0.2);
-	backdrop-filter: blur(50px);
-	border-bottom: 1px solid rgba(226, 232, 240, 0.85);
+	min-height: var(--header-height);
+	padding: 0.85rem 25px;
+	background: rgba(255, 255, 255, 0.58);
+	backdrop-filter: blur(28px);
+	-webkit-backdrop-filter: blur(28px);
+	border-bottom: 1px solid var(--glass-border);
+	box-shadow: 0 8px 24px rgba(160, 190, 215, 0.16);
 }
 
 .site-nav-shell {
@@ -89,6 +98,7 @@ body {
     font-family: "smalle";
     text-decoration: none;
 	font-weight: 600;
+	color: var(--angel-text);
 }
 
 .site-nav-links {
@@ -102,13 +112,15 @@ body {
     text-decoration: none;
 	position: relative;
 	color: var(--text-main);
+	transition: color 0.2s ease, transform 0.2s ease;
 }
 
 .site-nav-link:hover {
-	color: var(--primary-300);
+	color: var(--ink-faint);
+	transform: translateY(-1px);
 }
 .site-nav-link[aria-current="page"] {
-	color: #acbccc;
+	color: var(--ink-faint);
 }
 
 .site-footer {
@@ -116,26 +128,55 @@ body {
 	font-size: 14px;
 	color: var(--text-muted);
 	border-top: 1px solid var(--border);
+	padding: 1rem 0;
+}
+
+ .hamburger {
+	display: none;
+}
+
+a, button, img, .card, .gallery-tile, .bangumi-item, .sticker, .year-select {
+	transition-timing-function: ease;
+}
+
+main#main > *, .page-fade > * {
+	animation: contentFloat 0.55s ease both;
 }
 
 @keyframes pageFade {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes contentFloat {
 	from {
 		opacity: 0;
+		transform: translateY(10px);
 	}
 	to {
 		opacity: 1;
+		transform: translateY(0);
 	}
 }
 
-/* 手机端📱 */
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		scroll-behavior: auto !important;
+		transition-duration: 0.01ms !important;
+	}
+}
 
 @media (max-width: 768px) {
-    .sitecard {
-
-    }
-
+	:root {
+		--header-height: 3.75rem;
+	}
+	body {
+		padding: var(--header-height) 1rem 0;
+	}
 	main#main {
-		width: calc(100%);
+		width: 100%;
 		margin-top: 12px;
 	}
 	#main-header {
@@ -145,104 +186,51 @@ body {
 		display:none;
 	}
 
-
-    /*🍔*/
-
     .hamburger {
-		background-color: #acbccc;
-		border: 1px solid #acbccc;
+		background-color: var(--angel-blue);
+		border: 1px solid var(--angel-blue-light);
         display:block;
 		padding: 0em 1em;
 		margin: 0;
-		color:#ffffff;
+		color: var(--angel-text);
 		border-radius:15px;
 		font-weight: 800;
 		font-family: "smalle";
     }
 
 	.ham-nav-menu {
-		border:1px dashed #becfe8;
+		border:1px dashed var(--angel-blue-light);
 		border-top: none;
         display: none;
         position: fixed;
-        top: 3.14em;
+        top: var(--header-height);
         width: 100%;
 		left:0;
         height: auto;
-	    background: rgb(255 255 255 / 0.73);
+	    background: var(--card-bg);
+		backdrop-filter: blur(18px);
         padding: 0;
         z-index: 100;
+		transform-origin: top;
+		transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+		transform: scaleY(0);
+		opacity: 0;
     }
 
 	.ham-nav-menu p{
 		text-align: center;
 		font-size:medium;
 	}
-	.ham-nav-menu p ::before {
-		content: "- ";
-	}
-	
-	.ham-nav-menu p ::after {
-		content: " -";
-	}
-
-	.ham-nav-menu a{
-        text-decoration: none !important;
-	}
-
-	
-	/* 展开状态 */
-	.ham-nav-menu.ham-open {
-	  display: block;
-	  max-height: 500px;  /* 足够大的值，根据你的菜单项数量调整 */
-	  opacity: 1;
-	}
-	
-	/* 或者用 transform 动画（更流畅） */
-	.ham-nav-menu {
-	  display: none;
-	  transform-origin: top;
-	  transition:transform 0.2s ease-out transform  0.2s ease-out;
-	  transform: scaleY(0);
-	  opacity: 0;
-	}
-	
+	.ham-nav-menu p ::before { content: "- "; }
+	.ham-nav-menu p ::after { content: " -"; }
+	.ham-nav-menu a{ text-decoration: none !important; }
 	.ham-nav-menu.ham-open {
 	  display: block;
 	  transform: scaleY(1);
 	  opacity: 1;
 	}
-
 	.ham-nav-menu ul {
-  padding-left: 0;
-  text-align: center;
-}
-
-.ham-nav-menu p {
-  margin: 0;
-  text-align: center;
-}
-
-.ham-nav-menu a {
-  display: inline-block;    /* 或者用 block */
-  text-align: center;
-}
-
-
-    body{
-        margin-top: 20px;
-       padding: 0% 4%;
-    }
-}
-
-
-/* 桌面端💻 */
-@media (min-width: 769px) {
-    .hamburger {
-        display: none;
-    }
-
-	.ham-nav-menu {
-		display:none;
+		padding-left: 0;
+		text-align: center;
 	}
 }

--- a/src/styles/components/admonition.css
+++ b/src/styles/components/admonition.css
@@ -33,22 +33,22 @@
 }
 
 .admonition[data-admonition-type="note"] {
-	--admonition-color: #60a5fa;
-	background: #60a5fa0d;
+	--admonition-color: var(--angel-blue);
+	background: rgba(184, 212, 232, 0.16);
 }
 .admonition[data-admonition-type="tip"] {
-	--admonition-color: #84cc16;
-	background: #84cc160d;
+	--admonition-color: var(--ink-faint);
+	background: rgba(138, 163, 185, 0.12);
 }
 .admonition[data-admonition-type="important"] {
-	--admonition-color: #c084fc;
-	background: #c084fc0d;
+	--admonition-color: var(--ink-soft);
+	background: rgba(93, 115, 136, 0.12);
 }
 .admonition[data-admonition-type="caution"] {
-	--admonition-color: #fb923c;
-	background: #fb923c0d;
+	--admonition-color: var(--angel-gray);
+	background: rgba(216, 223, 230, 0.16);
 }
 .admonition[data-admonition-type="warning"] {
-	--admonition-color: #ef4444;
-	background: #ef44440d;
+	--admonition-color: var(--angel-text);
+	background: rgba(74, 93, 110, 0.10);
 }

--- a/src/styles/components/github-card.css
+++ b/src/styles/components/github-card.css
@@ -1,5 +1,5 @@
 .github-card {
-	background: #384d5e0d;
+	background: rgba(184, 212, 232, 0.18);
 	border-radius: 0.375rem;
 	padding: 0.75rem 1rem;
 }
@@ -17,7 +17,7 @@
 	height: 1.5rem;
 	flex: none;
 	border-radius: 999px;
-	background-color: #384d5e33;
+	background-color: rgba(184, 212, 232, 0.35);
 	background-size: cover;
 	background-position: center;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@
 @import "./base.css";
 @import url("https://cdn.jsdelivr.net/gh/isntbunny/web-fonts@main/ark/result.css");
 
+@import url('https://fonts.googleapis.com/css2?family=Cherry+Bomb+One&family=Yomogi&display=swap');
 @font-face {
   font-family: "Decima Mono Pro";
   src: url(https://file.garden/ZkRD3wbiZDsBIZnn/DecimaMonoPro.ttf);
@@ -20,32 +21,46 @@ src: url('https://file.garden/Z2X1AFY0KC4btVJr/links/smalle.ttf');}
 @font-face {
                 font-family: Pixel Operator;
                 src: url('https://ghostingpen.net/fonts/PixelOperator.ttf');}
-@import url('https://fonts.googleapis.com/css2?family=Cherry+Bomb+One&family=Yomogi&display=swap');
 :root {
-    /* 文字的配色 */
-	--text-main: #468;
-	--text-muted: #aaa;
-	--color-global-text: #384d5e;
-	--color-link: #4f7490;
-	--color-accent: #5791b6;
-	--color-accent-2: #2f4e62;
-	--color-quote: #ccc;
-    /* 卡片的配色 */
-	--border: #e2e8f0;
-	--color-surface: #ffffffb3;
-	--color-surface-dark: #212d42d1;
-	--card-shadow: 0 4px 12px #59d;
-	--hover-shadow: 0 8px 20px #ddd;
-    /* 界面的配色 */
-	--color-global-bg: #edf4f7;
-	--bg-main: #f0f7fa;
-	--color-bg-overlay: #ecf5f8c7;
-	--primary-100: #e1f5f8;
-	--primary-200: #d4f0f5;
-	--primary-300: #c7e9f0;
-	--white: #fffd;
-    --blue: #9cf;
+	/* 主页同款雾蓝手帐配色：所有页面请优先使用这些变量 */
+	--angel-blue: #b8d4e8;
+	--angel-blue-light: #d6e8f5;
+	--angel-blue-pale: #eaf2f9;
+	--angel-gray: #d8dfe6;
+	--angel-text: #4a5d6e;
+	--angel-shadow: rgba(160, 190, 215, 0.2);
+	--angel-shadow-strong: rgba(160, 190, 215, 0.35);
+	--card-bg: rgba(255, 255, 255, 0.65);
+	--card-bg-hover: rgba(255, 255, 255, 0.78);
+	--glass-bg: rgba(255, 255, 255, 0.4);
+	--glass-border: rgba(210, 225, 240, 0.5);
+	--paper-bg: #eef4f8;
+	--paper-bg-soft: #f6fbfd;
+	--ink-soft: #5d7388;
+	--ink-faint: #8aa3b9;
 
+	/* 旧变量映射到全局主页配色，便于各页面统一 */
+	--text-main: var(--angel-text);
+	--text-muted: var(--ink-faint);
+	--color-global-text: var(--angel-text);
+	--color-link: var(--ink-soft);
+	--color-accent: var(--angel-blue);
+	--color-accent-2: var(--ink-soft);
+	--color-quote: var(--ink-faint);
+	--border: var(--glass-border);
+	--color-surface: var(--card-bg);
+	--color-surface-dark: rgba(74, 93, 110, 0.82);
+	--card-shadow: 0 2px 14px var(--angel-shadow);
+	--hover-shadow: 0 6px 20px var(--angel-shadow-strong);
+	--color-global-bg: var(--paper-bg);
+	--bg-main: var(--paper-bg);
+	--color-bg-overlay: rgba(234, 242, 249, 0.78);
+	--primary-100: var(--angel-blue-pale);
+	--primary-200: var(--angel-blue-light);
+	--primary-300: var(--angel-blue);
+	--white: rgba(255, 255, 255, 0.87);
+	--blue: var(--angel-blue);
+	--header-height: 4.25rem;
 }
 
 
@@ -79,6 +94,6 @@ a {
 	color: var(--text-main);
 	text-decoration: underline;
     text-decoration-style: dashed;
-	text-decoration-color: #acbccc;
+	text-decoration-color: var(--angel-blue);
 	text-underline-offset: 5px;
 }

--- a/src/styles/pages/about.css
+++ b/src/styles/pages/about.css
@@ -28,7 +28,7 @@ h2{
 }
 
 .mybio {
-  color: #6c6c6c;
+  color: var(--ink-soft);
   font-size: 0.9rem;
   margin-bottom: 0.75rem;
 }
@@ -38,11 +38,11 @@ h2{
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
-  border-top: 1px solid #BECFE8;
-  border-bottom: 1px solid #BECFE8;
+  border-top: 1px solid var(--angel-blue-light);
+  border-bottom: 1px solid var(--angel-blue-light);
   padding: 0.2rem 0;
   justify-content: center;
-  background: rgb(255 255 255 / 0.73);
+  background: var(--card-bg);
 }
 
 .attribar img {
@@ -144,7 +144,7 @@ h2{
 .skills-section h3 {
   font-size: 1.2rem;
   margin-top: 0.5rem;
-  color: #555;
+  color: var(--angel-text);
   text-align: center;
 }
 
@@ -257,7 +257,7 @@ h2{
 
 @media (max-width: 768px) {
   .ham-nav-menu {
-    border:1px dashed #becfe8;
+    border:1px dashed var(--angel-blue-light);
     border-top: none;
     display: none;
     position: fixed;
@@ -265,7 +265,7 @@ h2{
     width: 100%;
     left:0;
     height: auto;
-    background: rgb(255 255 255 / 0.4);
+    background: var(--glass-bg);
     backdrop-filter: 50px;
     padding: 0;
     z-index: 100;

--- a/src/styles/pages/bangumi.css
+++ b/src/styles/pages/bangumi.css
@@ -7,12 +7,12 @@
 .bangumi-tab {
 	background: transparent;
 	border: 0;
-	color: #a0aec0;
+	color: var(--ink-faint);
 	padding: 2px 0;
 }
 .bangumi-tab.is-active {
-	color: #c7e9f0;
-	border-bottom: 2px solid #c7e9f0;
+	color: var(--angel-blue);
+	border-bottom: 2px solid var(--angel-blue);
 }
 .bangumi-grid {
 	display: grid;
@@ -35,5 +35,5 @@
 }
 .bangumi-item:hover img {
 	transform: translateY(-2px);
-	box-shadow: 0 8px 20px rgba(199, 233, 240, 0.3);
+	box-shadow: 0 8px 20px var(--angel-shadow-strong);
 }

--- a/src/styles/pages/gallery.css
+++ b/src/styles/pages/gallery.css
@@ -33,18 +33,18 @@
 }
 
 .gallery-grid::-webkit-scrollbar-track {
-	background: #e2e8f0;
+	background: var(--angel-blue-light);
 	border-radius: 3px;
 }
 
 .gallery-grid::-webkit-scrollbar-thumb {
-	background: #94a3b8;
+	background: var(--ink-faint);
 	border-radius: 3px;
 }
 
 
 .gallery-year-section {
-	background: #ffffff99;
+	background: var(--card-bg);
 	padding: 2em;
 	border-radius: 10px;
 }
@@ -59,11 +59,11 @@
 }
 
 .gallery-year-title {
-	background-color: #c5c5c5;
-	color: #fff;
+	background-color: var(--angel-gray);
+	color: var(--white);
 	font-size: 1.75rem;
 	padding:1em;
-	border-bottom: 2px solid #e2e8f0;
+	border-bottom: 2px solid var(--angel-blue-light);
 }
 
 .gallery-month-group {
@@ -78,7 +78,7 @@
 	width: 100px;
 	font-size: 1.125rem;
 	font-weight: 600;
-	color: #4a5568;
+	color: var(--angel-text);
 	padding: 1em;
 	background-color:gainsboro;
 }
@@ -120,7 +120,7 @@
 	position: absolute;
 	inset: 0;
 	border-radius: 12px;
-	background: linear-gradient(90deg, #d4f0f5, #e8f6fa, #d4f0f5);
+	background: linear-gradient(90deg, var(--angel-blue-light), var(--angel-blue-pale), var(--angel-blue-light));
 	background-size: 200% 200%;
 	animation: shimmer 1.2s infinite;
 }
@@ -157,13 +157,13 @@
 	border-radius: 12px;
 }
 .gallery-lightbox p {
-	color: #fff;
+	color: var(--white);
 	text-align: center;
 }
 .gallery-arrow {
 	border: 1px solid rgba(255, 255, 255, 0.4);
 	background: rgba(255, 255, 255, 0.1);
-	color: #fff;
+	color: var(--white);
 	border-radius: 20px;
 	padding: 10px;
 }

--- a/src/styles/pages/index.css
+++ b/src/styles/pages/index.css
@@ -1,28 +1,19 @@
-/* ===== 全局手帐配色 ===== */
-:root {
-  --angel-blue: #b8d4e8;
-  --angel-blue-light: #d6e8f5;
-  --angel-blue-pale: #eaf2f9;
-  --angel-gray: #d8dfe6;
-  --angel-text: #4a5d6e;
-  --angel-shadow: rgba(160, 190, 215, 0.2);
-  --card-bg: rgba(255, 255, 255, 0.65);
-}
+/* ===== 配色继承自 src/styles/global.css 的全局手帐色板 ===== */
 
 /* ===== 主体背景 ===== */
 body {
-  background: #eef4f8;
+  background: var(--paper-bg);
 }
 
 /* ===== 贴纸墙 ===== */
 .sticker-wall {
-  background: rgba(255, 255, 255, 0.4);
+  background: var(--glass-bg);
   backdrop-filter: blur(3px);
   border-radius: 28px;
   padding: 20px 24px;
   margin-bottom: 28px;
-  border: 1px solid rgba(210, 225, 240, 0.5);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--glass-border);
+  box-shadow: inset 0 0 0 1px var(--white);
   position: relative;
 }
 
@@ -30,13 +21,13 @@ body {
   position: absolute;
   top: -12px;
   left: 28px;
-  background: #eaf2f9;
+  background: var(--angel-blue-pale);
   padding: 0 16px;
   font-size: 13px;
-  color: #7a92a8;
+  color: var(--ink-faint);
   letter-spacing: 3px;
   border-radius: 30px;
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--white);
   backdrop-filter: blur(4px);
 }
 
@@ -49,20 +40,20 @@ body {
 }
 
 .sticker {
-  background: rgba(255, 255, 255, 0.7);
+  background: var(--card-bg);
   backdrop-filter: blur(2px);
   padding: 8px 12px;
   border-radius: 20px 8px 20px 8px;
   box-shadow: 0 2px 10px var(--angel-shadow);
-  border: 1px solid rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--white);
   transition: all 0.25s;
   position: relative;
 }
 
 .sticker:hover {
   transform: scale(1.05) rotate(0deg) !important;
-  box-shadow: 0 6px 20px rgba(160, 190, 215, 0.35);
-  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 6px 20px var(--angel-shadow-strong);
+  background: var(--card-bg-hover);
 }
 
 .sticker::before {
@@ -72,7 +63,7 @@ body {
   left: 25%;
   width: 30%;
   height: 10px;
-  background: rgba(210, 225, 240, 0.4);
+  background: var(--glass-border);
   border-radius: 20px 20px 0 0;
   filter: blur(1px);
   opacity: 0.5;
@@ -112,14 +103,14 @@ body {
   backdrop-filter: blur(3px);
   border-radius: 24px;
   padding: 20px 24px;
-  border: 1px solid rgba(210, 225, 240, 0.5);
+  border: 1px solid var(--glass-border);
   box-shadow: 0 2px 14px var(--angel-shadow);
   transition: 0.25s;
 }
 
 .sitecard:hover {
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: 0 4px 20px rgba(160, 190, 215, 0.25);
+  background: var(--card-bg-hover);
+  box-shadow: 0 4px 20px var(--angel-shadow);
 }
 
 .sitecard h1 {
@@ -141,7 +132,7 @@ body {
 }
 
 .sitecard p {
-  color: #5d7388;
+  color: var(--ink-soft);
   font-size: 15px;
   line-height: 1.8;
   margin: 4px 0;
@@ -167,26 +158,26 @@ body {
 
 /* ===== Status 样式 ===== */
 #statuscafe-content {
-  color: #5d7388;
+  color: var(--ink-soft);
   font-size: 14px;
   padding: 4px 0;
   font-style: italic;
 }
 
 #statuscafe-username {
-  color: #8aa3b9;
+  color: var(--ink-faint);
   font-size: 13px;
 }
 
 /* ===== Countdown ===== */
 .distance-label {
-  color: #5d7388;
+  color: var(--ink-soft);
   font-size: 15px;
   margin-bottom: 6px;
 }
 
 .year-select {
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--white);
   border: 1px solid var(--angel-blue-light);
   border-radius: 30px;
   padding: 2px 12px;
@@ -199,7 +190,7 @@ body {
 
 .year-select:focus {
   border-color: var(--angel-blue);
-  box-shadow: 0 0 0 3px rgba(184, 212, 232, 0.2);
+  box-shadow: 0 0 0 3px var(--angel-shadow);
 }
 
 .days-number {
@@ -219,7 +210,7 @@ body {
 }
 
 .reading-list li {
-  color: #5d7388;
+  color: var(--ink-soft);
   font-size: 15px;
   padding: 4px 0 4px 20px;
   position: relative;
@@ -235,7 +226,7 @@ body {
 /* ===== ToDo 占位 ===== */
 .todo-placeholder {
   min-height: 40px;
-  background: rgba(255, 255, 255, 0.3);
+  background: var(--glass-bg);
   border-radius: 16px;
   border: 1px dashed var(--angel-blue-light);
   position: relative;
@@ -247,7 +238,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #b0c4d6;
+  color: var(--ink-faint);
   font-size: 13px;
   letter-spacing: 1px;
 }
@@ -257,9 +248,9 @@ body {
   margin-top: 32px;
   text-align: center;
   font-size: 13px;
-  color: #b0c4d6;
+  color: var(--ink-faint);
   letter-spacing: 3px;
-  border-top: 1px dashed rgba(180, 200, 220, 0.3);
+  border-top: 1px dashed var(--glass-border);
   padding-top: 20px;
 }
 

--- a/src/styles/pages/posts.css
+++ b/src/styles/pages/posts.css
@@ -19,7 +19,7 @@
 }
 
 .posts-page .posts-year-divider {
-	border-top: 2px dashed #e2e8f0;
+	border-top: 2px dashed var(--angel-blue-light);
 	margin: 0%;
 }
 
@@ -30,7 +30,7 @@
 
 .posts-page .posts-month {
 	display: inline-block;
-	background: #bbdeff79;
+	background: var(--angel-blue-pale);
 	border-radius: 999px;
 	padding: 4px 12px;
 }
@@ -38,7 +38,7 @@
 .posts-page .posts-list {
 	margin: 10px 0 0 24px;
 	padding-left: 14px;
-	border-left: 2px solid #c7e9f0;
+	border-left: 2px solid var(--angel-blue);
 	display: grid;
 	gap: 8px;
 }


### PR DESCRIPTION
### Motivation
- Make the site visually consistent by promoting the homepage "soft blue notebook" palette to a global set of CSS variables and have all pages/components derive colors from that single palette. 
- Keep the header `position: fixed` while ensuring it no longer covers page content by making the layout header-aware. 
- Improve perceived polish by adding smooth, lightweight entrance and interaction animations while respecting `prefers-reduced-motion`. 

### Description
- Introduced a global color palette and legacy-variable mapping in `src/styles/global.css` (e.g. `--angel-*` variables and mapped `--text-main`, `--border`, etc.).
- Added header-aware layout spacing and scroll offsets via `--header-height`, `scroll-padding-top`, and top padding on `body` in `src/styles/base.css` so fixed header no longer overlaps content.
- Reworked base/card/nav styles and added animations and transitions (card float, content fade, hamburger menu scale, hover/touch transitions) with `prefers-reduced-motion` support in `src/styles/base.css` and applied consistent transitions across `src/styles/pages/*` and `src/styles/components/*`.
- Updated page/component styles to use the global palette, including `src/styles/pages/index.css`, `src/styles/pages/posts.css`, `src/styles/pages/gallery.css`, `src/styles/pages/about.css`, `src/styles/components/admonition.css`, `src/styles/components/github-card.css`, `src/components/blog/TOC.astro`, `src/components/GithubCommits.astro` and `src/pages/nav/index.astro` (color replacements and small layout refinements).

### Testing
- Ran `pnpm build` and static site generation completed successfully (site built and Pagefind index generated). 
- Ran `pnpm check` which reported TypeScript/Astro diagnostics (many pre-existing type errors in components like `GithubCommits.astro`, `HamburgerMenu.astro`, and data utilities) and therefore failed; these errors are unrelated to the styling changes in this PR. 
- Verified files were committed after the changes and a PR metadata entry was prepared for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b2ab7f514832cbdb73e75e27866c5)